### PR TITLE
Split apps section into applications and games

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -259,3 +259,12 @@ h1.title {
         font-size: 1.2em;
     }
 }
+
+/* Botón CTA: efecto de “subir” al pulsar */
+.cta {
+    transition: transform .25s ease;
+}
+
+.cta.cta-rise {
+    transform: translateY(-12px);
+}

--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@
 
         <header class="relative text-center py-6">
             <div class="flex justify-center items-center gap-4">
-                <img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAIBAQIBAQICAgICAgICAwUDAwMDAwYEBAMFBwYHBwcGBwcICQsJCAgKCAcHCg0KCgsMDAwMBwkODw0MDgsMDAz/2wBDAQICAgMDAwYDAwYMCAcIDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAz/wAARCAF3AMsDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1VWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uLj5OXm5+jp6vLz9PX29/j5+v/aAAwDAQACEQMRAD8A/v4ooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooAKKKKACiiigAooooA//Z" alt="Logo Rubenpantxo" class="h-16">
+                <img id="site-logo" src="img/logo.PNG" alt="Logo Rubenpantxo" class="h-16">
                 <h1 class="titulo-principal text-5xl md:text-7xl font-bold">Rubenpantxo.com</h1>
             </div>
             
@@ -174,7 +174,8 @@
 
         <nav id="main-nav" class="flex flex-col sm:flex-row justify-center items-center gap-8 sm:gap-12 mt-8">
             <div class="nav-item text-xl p-4 rounded-lg" data-section="noticias">Noticias y Artículos</div>
-            <div class="nav-item text-xl p-4 rounded-lg" data-section="apps">Apps y Entretenimiento</div>
+            <div class="nav-item text-xl p-4 rounded-lg" data-section="apps">Aplicaciones</div>
+            <div class="nav-item text-xl p-4 rounded-lg" data-section="games">Juegos</div>
             <div class="nav-item text-xl p-4 rounded-lg" data-section="enlaces">Enlaces Web</div>
         </nav>
 
@@ -186,7 +187,7 @@
                         <h3 class="text-2xl font-bold border-b-2 pb-2 border-gray-400">Últimas de Tecnología y Salud</h3>
                         
                         <div class="p-4 border rounded-lg bg-white shadow-md flex gap-4 items-start">
-                            <img src="https://www.basquequantum.eus/wp-content/uploads/2024/03/IBM-Quantum-System-Two-front-1024x576.jpg" alt="IBM Quantum System Two" class="w-24 h-24 rounded-md object-cover">
+                            <img src="img/Noticias/Img_Noti_1.png" alt="Render del IBM Quantum System Two en Euskadi" loading="lazy" class="w-24 h-24 rounded-md object-cover">
                             <div>
                                 <h4 class="font-bold text-lg">Primer 'IBM Quantum System Two' de Europa en Euskadi</h4>
                                 <p class="text-sm text-gray-700">El Gobierno Vasco e IBM instalarán en el IBM-Euskadi Quantum Computational Center el primer ordenador cuántico de este tipo fuera de EE.UU., impulsando la investigación y el desarrollo tecnológico en la región.</p>
@@ -195,7 +196,7 @@
                         </div>
                         
                         <div class="p-4 border rounded-lg bg-white shadow-md flex gap-4 items-start">
-                            <img src="https://news.mit.edu/sites/default/files/images/201908/MIT-Robotic-Thread-01.jpg" alt="Hilo robótico para el cerebro" class="w-24 h-24 rounded-md object-cover">
+                            <img src="img/Noticias/Img_Noti_2.png" alt="Hilo robótico guiado para el cerebro" loading="lazy" class="w-24 h-24 rounded-md object-cover">
                             <div>
                                 <h4 class="font-bold text-lg">Hilo Robótico para Vasos Sanguíneos del Cerebro</h4>
                                 <p class="text-sm text-gray-700">Investigadores del MIT han desarrollado un hilo robótico, controlado magnéticamente, capaz de navegar por los vasos sanguíneos del cerebro para tratar aneurismas y derrames sin necesidad de cirugía invasiva.</p>
@@ -204,7 +205,7 @@
                         </div>
 
                         <div class="p-4 border rounded-lg bg-white shadow-md flex gap-4 items-start">
-                            <img src="https://assets.shebaonline.org/wp-content/uploads/2021/11/Focused-ultrasound-for-Parkinsons-at-Sheba.jpg" alt="Tratamiento de Parkinson con ultrasonido" class="w-24 h-24 rounded-md object-cover">
+                            <img src="img/Noticias/Img_Noti_3.png" alt="Paciente recibe ultrasonido focalizado para el Parkinson" loading="lazy" class="w-24 h-24 rounded-md object-cover">
                             <div>
                                 <h4 class="font-bold text-lg">Avance en Parkinson: Ultrasonido Focalizado</h4>
                                 <p class="text-sm text-gray-700">El Centro Médico Sheba en Israel utiliza ultrasonido focalizado (FUS) no invasivo para tratar síntomas motores del Parkinson, permitiendo una recuperación rápida sin cirugía cerebral abierta.</p>
@@ -213,21 +214,21 @@
                         </div>
 
                         <div class="p-4 border rounded-lg bg-white shadow-md flex gap-4 items-start">
-                            <img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAH0A+gDASIAAhEBAxEB/8QAHQAAAQQDAQEAAAAAAAAAAAAABwAFBggBAgMECf/EAE4QAAEDAwIEAwUEBgYHBgQHAQECAwQABQYRBxIhMQgTQRQiUWEVUnGBFjIzQlKhCCNicqKxFjQ2N0R0stElJjdUZIOzwcInRFRkg6L/xAAUAQEAAAAAAAAAAAAAAAAAAAAA/8QAFBEBAAAAAAAAAAAAAAAAAAAAAP/aAAwDAQACEQMRAD8A0z0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p0p-h/jU03wA++gP+A7w/wAKmm/+fOD/AOjzP/3UB/wDeH+FTTf8Az5wf/R5v/wC1ATQ+Cnh2D/qE6af+zX//AHVKPCfh2P8AqE6Z+dp/6qA3/wCEU8P/APQJ0z87T/1R/wAIp4f/AOgTpn52n/qgJg+GPD6f+gRpY/7tI/8AiqT/AIRzQP8AoEaV/wCMB/8AFQG/PhzQP+gTpf8A4xH/AMVDw5oJ/wCgTpf/AIxH/wAVAb/8I7oH/QI0v/xiP/ipP+Ee0D/oE6X/AOMR/wDFQG/Ph7QP+gTpf/jEf/FRHh7QP+gRpf8A4xH/AMVAb/8ACPaB/wBAjS//ABiP/iojw9oH/QI0v/xiP/ioDf/hHtA/6BGl/wDjEf8AxUf8I/oH/QI0v/xiP/ioDf8A4R/QP+gRpf8A4xH/AMVPjw/oA/6BGlf+MR/8VAbEeINAH/QI0r/xiP8A4qcPA3hz/oFWX/lVAbA8A+HD/wBAuy/8qp/8ID4d/wCgXZf+VUBL4C8O/wDQJs//ACqnx4E8O/8AQJs//KqAlfAPhz/oE2f/AJVT/wCAfhz/AKBNn/5VQE3/AAP8N/8AQIs//AChT14E8O/8AQJs//KqAl/4QPDf/ANAqy/8AKf8A1VIfBPhsf9Aqy/8AIf8A1UBsLwf4b/6A9l/5D/1VIeE/Df8A0B7L/wAif+qgNgeDPDY/6A9l/wCQ/wDVQGweD/Df/QHsv/If+qgNgeDvDY/6A9l/5D/1UeHPDZ/6A9l/5D/1UBsDwj4bP/QGsv8AyB/qpP8AhD/DX/QGsv8AyA/qgNgeDfDX/QGsv/ID+qP+EN8Nf9Aay/8AID+qA2B4Q8Nf9Aay/wDIT/VSjwj4a/6A1l/5Kf6qA2B4Q8M/9Aey/wDJT/VSnwf4Z/6A9l/5Kf6qAnB4L8Mj/oD2X/kp/qpx4J8Nf9Aey/8AIf8AqgJ/+FM8Nf8AQHsv/If+qlHhLw2f+gNZf+Sn+qgJh4O8N/8AQHsv/If+qgPBsH/QHsv/ACH/AKoCYPBfhn/oD2X/AJD/ANVH/CF+Gf8AoD2X/kP/AFUBP/whfhgf9Aey/wDIf+qk/wCEL8M/9Aey/wDIf+qgJv8AhDfDI/6A9l/5Kf6qf/hCvDP/AECbL/yH/qoCYeD/AAz/ANAmy/8AIf8Aqp/+EP8ADX/QJsv/ACH/AKqAlHhHw1/0CbL/AMh/6qDwl4a/6A9l/wCQ/wDVQE3/AAhPhn/oD2X/AJD/ANVOng/wzH/zBrL/AMh/6qAnU8JeGo/+YNZf+SH+qk/4RHw5/wBAay/8kP8AVQEw8I+G/wDoDWX/AJKf6qUeFPDeP+YPY/+Sn+qgJMeFPDX/AEB7L/yU/wBVKPCvhr/oD2X/AJKf6qAmPC/hz/oEWX/kp/qpP+Ffhz/oEWX/AJKf6qAiPDXh0/8AQIsf/JT/AFUZ8J+Hj/zBLD/yU/wVARfhTw8f+YJYf+Sn+qpHhTw8f+YJYf8AkJ/qoDV3VvwL0H1T8PNOa9/N9v6T4e09f/mGWLf9zZFAf6qB8P6eP+Ydbf8AksKAPh9T/wCQdbf+SwoD4fU9v+Ydbf8AkIUA/UFPb/mHW3/kIUA/UFPb/mHW3/kIUA/UFPb/AJh1t/5CFAV9T2/5h1t/5CFAV9Q09v8AmG23/kIUBX1DTm/5h1r/AOQhQH1DTm/5htr/AOQhQGv1LTm/5htr/wCShQH1LTj/AMw22/8AJQoDFxpsf/MNtv8AyUKAxcaZP/zDbf8A8lCgP1HTP+gbbf8AkoUA/UVP/wA8+2/8lCgMXFOA/wA862/8lCgMXFOA/wA862/8lCgP/9k=" alt="Noticia sobre disco óptico" class="w-24 h-24 rounded-md object-cover">
+                            <img src="img/Noticias/Img_Noti_4.jpg" alt="Ilustración de disco óptico de 125 terabytes" loading="lazy" class="w-24 h-24 rounded-md object-cover">
                             <div>
                                 <h4 class="font-bold text-lg">Disco óptico de 125 TB</h4>
                                 <p class="text-sm text-gray-700">Un equipo chino presenta un soporte óptico con densidad récord, relevante para archivo frío, pero aún en fase de investigación sin cifras de coste, velocidad o durabilidad.</p>
                             </div>
                         </div>
                         <div class="p-4 border rounded-lg bg-white shadow-md flex gap-4 items-start">
-                             <img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAoHBwgHBgoICAgLCgoLDhgQDg0NDh0VFhEYIx8lJCIfIiEmKzcvJik0KSEiMEExNDk7Pj4+JS5ESUM8SDc9Pjv/2wBDAQoLCw4NDhwQEBw7KCIoOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozv/wAARCAE2ApsDASIAAhEBAxEB/8QAGwAAAgMBAQEAAAAAAAAAAAAAAgMAAQQFBgf/xAA3EAACAgEDAwMCBAYCAQUBAAAAAQIRAwQSEiEFMUFREyJhFHGBkUKhscEGFSIjM0Ji0eHxJDNy/8QAGAEBAQEBAQAAAAAAAAAAAAAAAAECAwT/xAAhEQEBAQEAAwEAAwEBAQEAAAABEQISIQMxQVFhE3EiMv/aAAwDAQACEQMRAD8A9XJ2FHYo7FHk7CjsUdijsUeTYUdijsUdiPJ2FHdiu7FdiPJ2FHYou7FdiPJ2FHYo7sV2I8nZk7FHYo7FHyNjspdjuz0FdiPJ2NlS7Fdiy9CrsR5OxsqXYrsV2K8nY2VLsV2LL0H2I8nZXZUuxXZku7FdiPk7K7KXYrsS7sV2I+RsqXZXYrsS7FdiPJ2NlS7FdiXYq7EeVs7FLYrsS7FdiPK2dljYrsV2JLsV2I8rZ2WOxXYkuxXYjytnZkuxXYkuxXYjytnZY7FdiS7FdiPK2dijsV2JXYq7EeVsdkuxXYkuxXYjytjsqXYrsSXYq7EeTY7KXYrsSXYrsR5WxsqXYrsSXYrsR5Wx2VLsV2JXYrsR5WxsqXYrsSXYrsR5WxsqXYrsSXYrsR5NjZUuxXYkuxXYjybGyj0XYkuxXYjybGyj0K7EuxXYjybGyj0K7EuxXYjybGyj0XYkuxXYjyNlHouxJdiuxHk2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTZR6FdiXYrsR5NlHoV2JdiuxHk2UehXYl2K7EeTY2UehXYl2K7EeTZR6FdiXYrsR5NlHoV2JdiuxHk2UehXYl2K7EeTY2UehXYl2K7EeTZR6FdiXYrsR5NlHoV2JdiuxHk2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2K7EeTY2UehXYl2-v//Z" alt="Noticia sobre perro-robot" class="w-24 h-24 rounded-md object-cover">
+                             <img src="img/Noticias/Img_Noti_5.jpg" alt="Prototipo del perro robot Black Panther 2.0" loading="lazy" class="w-24 h-24 rounded-md object-cover">
                             <div>
                                 <h4 class="font-bold text-lg">Perro-robot “Black Panther 2.0”</h4>
                                 <p class="text-sm text-gray-700">Asegura cubrir 100 m en menos de 10 s (>36 km/h), un salto frente a modelos comerciales. Se necesita verificación independiente de las condiciones de prueba y su autonomía.</p>
                             </div>
                         </div>
                         <div class="p-4 border rounded-lg bg-white shadow-md flex gap-4 items-start">
-                            <img src="data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwgIyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCj/wAARCAEsA7gDASIAAhEBAxEB/8QAHAAAAQUBAQEAAAAAAAAAAAAABQIDBAYHAAEI/8QAWhAAAQMCBAIECAoFBwcHCgcAAQIDBAURAAYSIQcxE0FRYSIUcYGRoQgyUpLB0SNCUrFSYnOC0uEkorPh8BYkM0Njc5OzwvFEVWR1g5SjGEVUdZXVJ0aV/8QAGQEBAAMBAQAAAAAAAAAAAAAAAAECAwQF/8QALhEBAAIBBAEDAwQCAwADAAAAAQIRAxIhBBMxQVEiYXEygcEFFJGhsRWhwZLw/9oADAMBAAIRAxEAPwDsoAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooAooA-v//Z" alt="Noticia sobre Photon Matrix" class="w-24 h-24 rounded-md object-cover">
+                            <img src="img/Technology.png" alt="Representación de la matriz láser Photon Matrix" loading="lazy" class="w-24 h-24 rounded-md object-cover">
                             <div>
                                 <h4 class="font-bold text-lg">“Photon Matrix” anti-mosquitos</h4>
                                 <p class="text-sm text-gray-700">Afirma usar IA y láseres para abatir hasta 40 mosquitos por segundo. Viable en entornos controlados, pero depende de la seguridad ocular, consumo y coste para su adopción.</p>
@@ -240,9 +241,34 @@
                 </div>
             </section>
 
-            <section id="apps-content" class="content-section content-hidden">
+            <section id="apps" class="content-section content-hidden section section--apps" aria-labelledby="apps-title">
+                <header class="section__header flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                    <h2 id="apps-title" class="text-3xl font-bold">Aplicaciones</h2>
+                    <button id="hero-cta" class="cta bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-2 rounded-lg shadow-md transition-transform" type="button">Explorar</button>
+                </header>
                 <div id="app-placas-container" class="bg-white text-gray-800 rounded-lg shadow-xl overflow-hidden my-4 -mx-4 sm:-mx-8">
-                    </div>
+                </div>
+            </section>
+
+            <section id="games" class="content-section content-hidden section section--games" aria-labelledby="games-title">
+                <header class="section__header flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+                    <h2 id="games-title" class="text-3xl font-bold">Juegos</h2>
+                    <button class="cta bg-blue-600 hover:bg-blue-700 text-white font-semibold px-6 py-2 rounded-lg shadow-md transition-transform" type="button">Explorar</button>
+                </header>
+                <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 my-4">
+                    <article class="bg-white rounded-lg shadow-md p-4 flex flex-col gap-2">
+                        <h3 class="text-xl font-semibold">Bit Builder</h3>
+                        <p class="text-sm text-gray-700">Puzzle de lógica inspirado en circuitos donde debes alinear energía para activar cada nodo.</p>
+                    </article>
+                    <article class="bg-white rounded-lg shadow-md p-4 flex flex-col gap-2">
+                        <h3 class="text-xl font-semibold">Geo Runner</h3>
+                        <p class="text-sm text-gray-700">Juego casual para explorar mapas y recolectar hitos mientras esquivas obstáculos.</p>
+                    </article>
+                    <article class="bg-white rounded-lg shadow-md p-4 flex flex-col gap-2 sm:col-span-2 lg:col-span-1">
+                        <h3 class="text-xl font-semibold">Solar Quest</h3>
+                        <p class="text-sm text-gray-700">Planifica instalaciones solares en tiempo limitado combinando paneles y perfiles.</p>
+                    </article>
+                </div>
             </section>
 
             <section id="enlaces-content" class="content-section content-hidden">
@@ -447,7 +473,7 @@
                     if (body.classList.contains('section-open')) return;
 
                     const sectionId = item.dataset.section;
-                    const targetSection = document.getElementById(sectionId + '-content');
+                    const targetSection = document.getElementById(sectionId + '-content') || document.getElementById(sectionId);
 
                     body.classList.add('section-open');
                     body.style.backgroundColor =  '#fdfdf8';
@@ -794,6 +820,29 @@
                 setupDragAndDrop();
                 appContainer.querySelector('.texture-thumb').click();
             }
+
+            const ctas = document.querySelectorAll('.cta');
+            ctas.forEach(btn => {
+                btn.addEventListener('click', () => {
+                    btn.classList.add('cta-rise');
+                    setTimeout(() => btn.classList.remove('cta-rise'), 300);
+                });
+            });
+
+            const internalLinks = document.querySelectorAll('a[href^="#"]');
+            internalLinks.forEach(anchor => {
+                anchor.addEventListener('click', event => {
+                    const href = anchor.getAttribute('href');
+                    if (!href || href === '#') {
+                        return;
+                    }
+                    const target = document.querySelector(href);
+                    if (target) {
+                        event.preventDefault();
+                        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                    }
+                });
+            });
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- replace the "Apps y Entretenimiento" navigation entry with separate Aplicaciones and Juegos sections while wiring the new content blocks
- point the site logo and technology news cards to local assets and add CTA buttons with a reusable rise animation
- enhance the UI script with the CTA effect and smooth scrolling fallback for internal anchors

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e015410b98832b9672597d4beb8aff