### PR TITLE
Añadir Rubenpantxo Garden Manager (accesible en móvil)

### DIFF
--- a/apps/rubenpantxo-garden/css/style.css
+++ b/apps/rubenpantxo-garden/css/style.css
@@ -23,26 +23,6 @@ input:focus, select:focus, textarea:focus {
 }
 label { font-size: 12px; font-weight: 600; color: var(--text-soft); text-transform: uppercase; letter-spacing: .5px; display: block; margin-bottom: 6px; }
 
-/* === BLOQUEO MÓVIL === */
-#mobile-block {
-  display: none;
-  position: fixed; inset: 0;
-  background: linear-gradient(135deg, #1a1f1a 0%, #2a3a2a 100%);
-  z-index: 9999;
-  align-items: center; justify-content: center;
-  padding: 32px;
-  text-align: center;
-  color: #f4ece2;
-}
-.mobile-block-inner { max-width: 420px; }
-.mobile-block-inner img { width: 80px; margin: 0 auto 24px; filter: drop-shadow(0 4px 16px rgba(0,0,0,.4)); }
-.mobile-block-inner h2 { font-family: 'Vito', sans-serif; font-size: 28px; margin-bottom: 16px; }
-.mobile-block-inner p { font-size: 15px; line-height: 1.6; margin-bottom: 12px; opacity: .9; }
-.mobile-block-hint { font-style: italic; opacity: .7; font-size: 14px; }
-@media (max-width: 1023px) {
-  #mobile-block { display: flex; }
-  body > *:not(#mobile-block) { display: none !important; }
-}
 
 /* === TOP BAR === */
 #top-bar {

--- a/apps/rubenpantxo-garden/index.html
+++ b/apps/rubenpantxo-garden/index.html
@@ -12,16 +12,6 @@
   <link rel="stylesheet" href="css/sections.css" />
 </head>
 <body>
-  <!-- Bloqueo móvil -->
-  <div id="mobile-block">
-    <div class="mobile-block-inner">
-      <img src="assets/icons/logo.png" alt="Logo" />
-      <h2>Optimizado para escritorio</h2>
-      <p>Esta aplicación requiere una pantalla de al menos <strong>1024px</strong> de ancho para ofrecer la mejor experiencia.</p>
-      <p class="mobile-block-hint">Abre <em>rubenpantxo.com</em> desde tu ordenador o tablet en horizontal.</p>
-    </div>
-  </div>
-
   <!-- BARRA SUPERIOR FIJA -->
   <header id="top-bar">
     <div class="top-bar-left">


### PR DESCRIPTION
$(cat <<'EOF'
## Resumen

- Añade la app **Rubenpantxo Garden Manager** en `apps/rubenpantxo-garden/` con todos sus archivos (CSS, JS, assets, fuentes, datos).
- Añade tarjeta de acceso en la sección de **aplicaciones privadas** del `index.html` principal.
- **Elimina el bloqueo móvil** que impedía abrir la app en pantallas menores de 1024px.

## Cambios

- `apps/rubenpantxo-garden/` — app completa (plantas, riego, stock, alertas, calendarios, infografías)
- `apps/rubenpantxo-garden/css/style.css` — eliminado el bloque `#mobile-block` y el media query que ocultaba el contenido en móvil
- `apps/rubenpantxo-garden/index.html` — eliminado el div de bloqueo móvil
- `index.html` — nueva tarjeta "Garden Manager" en apps privadas

## Test

- [ ] Abrir la web, iniciar sesión y verificar que aparece la tarjeta Garden Manager
- [ ] Pulsar la tarjeta y comprobar que la app carga correctamente en móvil y escritorio

https://claude.ai/code/session_01Ya8o43cWTJNVYQ6SJTTujE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ya8o43cWTJNVYQ6SJTTujE)_