### PR TITLE
Fix: eliminar blur y franja blanca del Garden Manager en móvil

### DIFF
--- a/apps/rubenpantxo-garden/css/style.css
+++ b/apps/rubenpantxo-garden/css/style.css
@@ -393,23 +393,55 @@ label { font-size: 12px; font-weight: 600; color: var(--text-soft); text-transfo
 
 /* === MÓVIL === */
 @media (max-width: 768px) {
+  /* Top bar */
   #top-bar {
     overflow: hidden;
     padding: 0 12px;
     height: 56px;
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background: rgba(20,30,20,.98);
   }
   .view { padding-top: 56px; }
-  .hub-stage { height: calc(100vh - 56px); overflow: auto; }
-  .top-bar-center { display: none; }
-  .actions-menu { display: none; }
+  .hub-stage { height: calc(100vh - 56px); overflow: hidden; }
+  .top-bar-center { display: none !important; }
+  .actions-menu { display: none !important; }
   .brand-name { font-size: 14px; }
   .brand-sub { display: none; }
   .brand-logo { width: 32px; height: 32px; }
-  .mini-nav { bottom: 12px; padding: 4px; gap: 2px; }
-  .mini-nav-btn { padding: 6px 10px; font-size: 10px; }
+
+  /* Eliminar backdrop-filter de hotspots — causa blur en mobile Chrome */
+  .hotspot {
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    background: rgba(255,255,255,.95);
+  }
+  .hotspot-label {
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+  }
+
+  /* Mini-nav opaco sin backdrop-filter */
+  .mini-nav {
+    bottom: 12px;
+    padding: 4px;
+    gap: 2px;
+    backdrop-filter: none !important;
+    -webkit-backdrop-filter: none !important;
+    background: rgba(20,30,20,.98);
+    left: 50%;
+    transform: translateX(-50%);
+    max-width: 96vw;
+  }
+  .mini-nav-btn { padding: 6px 8px; font-size: 10px; }
   .mini-nav-btn img { width: 18px; height: 18px; }
+
+  /* Modales y secciones */
   .modal-content { width: 95vw; padding: 20px; }
   .modal-content.wide { width: 95vw; }
   .section { padding: 20px 16px 100px; }
+
+  /* Asegurar que el modal oculto no interfiere */
+  #modal-root[hidden] { display: none !important; }
 }
 ::-webkit-scrollbar-thumb:hover { background: rgba(0,0,0,.28); }


### PR DESCRIPTION
## Problema

En móvil Android/Chrome aparecían dos problemas:
- **Capa difuminada** sobre toda la pantalla
- **Franja blanca** en el centro

## Causa raíz

Los elementos `.hotspot` (8 botones del hub) y `.mini-nav` tienen `backdrop-filter: blur()`. En Android Chrome, múltiples elementos con `backdrop-filter` en el mismo contexto de apilamiento causan un bug de renderizado que difumina toda la pantalla y genera artefactos blancos.

## Fix

En pantallas ≤ 768px:
- Se elimina `backdrop-filter` de todos los `.hotspot` y `.hotspot-label`
- Se elimina `backdrop-filter` del `.mini-nav` y `#top-bar`
- Los fondos pasan a ser opacos para compensar la pérdida del efecto glass
- Se añade `display: none !important` extra para el top-bar-center

https://claude.ai/code/session_01Ya8o43cWTJNVYQ6SJTTujE

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ya8o43cWTJNVYQ6SJTTujE)_