### PR TITLE
Cesta Punta: sonido de pelota realista

### DIFF
--- a/juegos/cesta-punta/index.html
+++ b/juegos/cesta-punta/index.html
@@ -76,9 +76,44 @@ const beep = (freq=440,dur=0.08,type='square',vol=0.15)=>{
   g.gain.setValueAtTime(vol,t); g.gain.exponentialRampToValueAtTime(0.0001,t+dur);
   o.connect(g).connect(actx.destination); o.start(t); o.stop(t+dur);
 };
+// Buffer de ruido blanco reutilizable (para impactos realistas)
+let noiseBuf=null;
+function getNoise(){
+  if(!noiseBuf){
+    const len=(actx.sampleRate*0.4)|0;
+    noiseBuf=actx.createBuffer(1,len,actx.sampleRate);
+    const d=noiseBuf.getChannelData(0);
+    for(let i=0;i<len;i++) d[i]=Math.random()*2-1;
+  }
+  return noiseBuf;
+}
+// Impacto "plas/pok" real de pelota: ráfaga de ruido filtrado + golpe grave.
+function impact({vol=0.4,dur=0.13,freq=2200,q=1.0,type='bandpass',thump=170,thumpVol=0.3,decayThump=0.5}={}){
+  if(!actx) return;
+  const t=actx.currentTime;
+  // Transitorio: ruido filtrado con caída muy rápida (el "plas")
+  const src=actx.createBufferSource(); src.buffer=getNoise();
+  const f=actx.createBiquadFilter(); f.type=type; f.frequency.setValueAtTime(freq,t); f.Q.value=q;
+  const g=actx.createGain();
+  g.gain.setValueAtTime(vol,t);
+  g.gain.exponentialRampToValueAtTime(vol*0.3,t+0.008);   // ataque seco
+  g.gain.exponentialRampToValueAtTime(0.0001,t+dur);
+  src.connect(f).connect(g).connect(actx.destination); src.start(t); src.stop(t+dur);
+  // Cuerpo: golpe grave con caída de tono (resonancia del frontón)
+  if(thump){
+    const o=actx.createOscillator(), og=actx.createGain();
+    o.type='sine'; o.frequency.setValueAtTime(thump,t);
+    o.frequency.exponentialRampToValueAtTime(thump*0.45,t+dur*decayThump);
+    og.gain.setValueAtTime(thumpVol,t);
+    og.gain.exponentialRampToValueAtTime(0.0001,t+dur*0.9);
+    o.connect(og).connect(actx.destination); o.start(t); o.stop(t+dur);
+  }
+}
 const sfx = {
-  wall: ()=>beep(210,.05,'square',.16),
-  hit:  ()=>{ beep(500,.04,'square',.16); setTimeout(()=>beep(770,.05,'square',.12),16); },
+  // Pelota contra el frontis/pared: crack seco y brillante con resonancia
+  wall: ()=>impact({vol:0.5,dur:0.16,freq:2600,q:0.7,type:'highpass',thump:200,thumpVol:0.35,decayThump:0.6}),
+  // Pelota atrapada y lanzada con la cesta de mimbre/cuero: "thwap" más grave
+  hit:  ()=>impact({vol:0.38,dur:0.11,freq:1100,q:1.4,type:'bandpass',thump:130,thumpVol:0.28,decayThump:0.5}),
   point:()=>{ beep(880,.07,'square',.2); setTimeout(()=>beep(1320,.1,'square',.2),70); },
   fault:()=>{ beep(170,.15,'sawtooth',.22); setTimeout(()=>beep(90,.2,'sawtooth',.18),90); },
   win:  ()=>{ [660,880,990,1320].forEach((f,i)=>setTimeout(()=>beep(f,.12,'square',.2),i*120)); },


### PR DESCRIPTION
## Sonido de pelota realista 🎾

El sonido anterior era un "beep" digital de onda cuadrada (tono puro), que sonaba demasiado electrónico. Este PR lo sustituye por un **impacto sintetizado** que imita el sonido real de una cancha de cesta punta.

### Cómo
Nuevo sintetizador `impact()` que combina:
- **Ráfaga de ruido blanco filtrado** con ataque seco y caída muy rápida → el **"¡PLAS!"** del cuero contra la superficie.
- **Golpe grave de seno** con caída de tono → la **resonancia del frontón** (el "pok" que retumba).

Diferenciado por material:
- **Contra el frontis/pared** (`wall`): crack seco y brillante con resonancia.
- **En la cesta** (`hit`): un *"thwap"* más grave y apagado (mimbre/cuero de la xistera).

Todo con Web Audio (síntesis pura, sin archivos de sonido → cero peso añadido).

> Nota: el cambio del sonido se había quedado fuera del PR #90 (que solo recogió el soporte móvil). Este PR lo reincorpora sobre `main`.

https://claude.ai/code/session_014h3xZe2gjsHi2NmXbaNUMY

---
_Generated by [Claude Code](https://claude.ai/code/session_014h3xZe2gjsHi2NmXbaNUMY)_