### PR TITLE
Restaurar sección Enlaces Web con 140 enlaces en 17 categorías

### DIFF
--- a/index.html
+++ b/index.html
@@ -491,7 +491,874 @@
                 </div>
             </section>
             <section id="enlaces-content" class="content-section content-hidden">
-                </section>
+                <div class="pt-8">
+                    <h3 class="text-2xl font-bold border-b-2 pb-2 border-gray-400 mb-6">Enlaces de Interés</h3>
+
+                    <!-- Grid de categorías -->
+                    <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+
+                        <!-- Mapas -->
+                        <div class="category-card cursor-pointer" data-category="mapas">
+                            <div class="rounded-t-lg p-6 flex flex-col items-center justify-center h-40">
+                                <i class="fas fa-map-marked-alt text-6xl text-green-600 mb-2 category-icon"></i>
+                                <h4 class="text-xl font-bold text-gray-800">Mapas</h4>
+                            </div>
+                            <div class="bg-gradient-to-b from-white/50 to-white/30 rounded-b-lg p-3">
+                                <p class="text-sm text-gray-700 text-center font-semibold">15 recursos</p>
+                            </div>
+                        </div>
+
+                        <!-- IAs -->
+                        <div class="category-card cursor-pointer" data-category="ias">
+                            <div class="rounded-t-lg p-6 flex flex-col items-center justify-center h-40">
+                                <i class="fas fa-brain text-6xl text-purple-600 mb-2 category-icon"></i>
+                                <h4 class="text-xl font-bold text-gray-800">IAs</h4>
+                            </div>
+                            <div class="bg-gradient-to-b from-white/50 to-white/30 rounded-b-lg p-3">
+                                <p class="text-sm text-gray-700 text-center font-semibold">15 recursos</p>
+                            </div>
+                        </div>
+
+                        <!-- Esquemas -->
+                        <div class="category-card cursor-pointer" data-category="esquemas">
+                            <div class="rounded-t-lg p-6 flex flex-col items-center justify-center h-40">
+                                <i class="fas fa-project-diagram text-6xl text-yellow-600 mb-2 category-icon"></i>
+                                <h4 class="text-xl font-bold text-gray-800">Esquemas</h4>
+                            </div>
+                            <div class="bg-gradient-to-b from-white/50 to-white/30 rounded-b-lg p-3">
+                                <p class="text-sm text-gray-700 text-center font-semibold">1 recurso</p>
+                            </div>
+                        </div>
+
+                        <!-- Developing -->
+                        <div class="category-card cursor-pointer" data-category="developing">
+                            <div class="rounded-t-lg p-6 flex flex-col items-center justify-center h-40">
+                                <i class="fas fa-code text-6xl text-blue-600 mb-2 category-icon"></i>
+                                <h4 class="text-xl font-bold text-gray-800">Developing</h4>
+                            </div>
+                            <div class="bg-gradient-to-b from-white/50 to-white/30 rounded-b-lg p-3">
+                                <p class="text-sm text-gray-700 text-center font-semibold">7 recursos</p>
+                            </div>
+                        </div>
+
+                        <!-- Blogs -->
+                        <div class="category-card cursor-pointer" data-category="blogs">
+                            <div class="rounded-t-lg p-6 flex flex-col items-center justify-center h-40">
+                                <i class="fas fa-blog text-6xl text-pink-600 mb-2 category-icon"></i>
+                                <h4 class="text-xl font-bold text-gray-800">Blogs</h4>
+                            </div>
+                            <div class="bg-gradient-to-b from-white/50 to-white/30 rounded-b-lg p-3">
+                                <p class="text-sm text-gray-700 text-center font-semibold">1 recurso</p>
+                            </div>
+                        </div>
+
+                        <!-- Multimedia -->
+                        <div class="category-card cursor-pointer" data-category="multimedia">
+                            <div class="rounded-t-lg p-6 flex flex-col items-center justify-center h-40">
+                                <i class="fas fa-photo-video text-6xl text-orange-600 mb-2 category-icon"></i>
+                                <h4 class="text-xl font-bold text-gray-800">Multimedia</h4>
+                            </div>
+                            <div class="bg-gradient-to-b from-white/50 to-white/30 rounded-b-lg p-3">
+                                <p class="text-sm text-gray-700 text-center font-semibold">2 recursos</p>
+                            </div>
+                        </div>
+
+                        <!-- Seguridad -->
+                        <div class="category-card cursor-pointer" data-category="seguridad">
+                            <div class="rounded-t-lg p-6 flex flex-col items-center justify-center h-40">
+                                <i class="fas fa-shield-alt text-6xl text-red-600 mb-2 category-icon"></i>
+                                <h4 class="text-xl font-bold text-gray-800">Seguridad</h4>
+                            </div>
+                            <div class="bg-gradient-to-b from-white/50 to-white/30 rounded-b-lg p-3">
+                                <p class="text-sm text-gray-700 text-center font-semibold">1 recurso</p>
+                            </div>
+                        </div>
+
+                        <!-- Curiosidades -->
+                        <div class="category-card cursor-pointer" data-category="curiosidades">
+                            <div class="rounded-t-lg p-6 flex flex-col items-center justify-center h-40">
+                                <i class="fas fa-lightbulb text-6xl text-cyan-600 mb-2 category-icon"></i>
+                                <h4 class="text-xl font-bold text-gray-800">Curiosidades</h4>
+                            </div>
+                            <div class="bg-gradient-to-b from-white/50 to-white/30 rounded-b-lg p-3">
+                                <p class="text-sm text-gray-700 text-center font-semibold">7 recursos</p>
+                            </div>
+                        </div>
+
+                        <!-- Herramientas -->
+                        <div class="category-card cursor-pointer" data-category="herramientas">
+                            <div class="rounded-t-lg p-6 flex flex-col items-center justify-center h-40">
+                                <i class="fas fa-tools text-6xl text-amber-600 mb-2 category-icon"></i>
+                                <h4 class="text-xl font-bold text-gray-800">Herramientas</h4>
+                            </div>
+                            <div class="bg-gradient-to-b from-white/50 to-white/30 rounded-b-lg p-3">
+                                <p class="text-sm text-gray-700 text-center font-semibold">10 recursos</p>
+                            </div>
+                        </div>
+
+                        <!-- Finanzas -->
+                        <div class="category-card cursor-pointer" data-category="finanzas">
+                            <div class="rounded-t-lg p-6 flex flex-col items-center justify-center h-40">
+                                <i class="fas fa-coins text-6xl text-emerald-600 mb-2 category-icon"></i>
+                                <h4 class="text-xl font-bold text-gray-800">Finanzas</h4>
+                            </div>
+                            <div class="bg-gradient-to-b from-white/50 to-white/30 rounded-b-lg p-3">
+                                <p class="text-sm text-gray-700 text-center font-semibold">10 recursos</p>
+                            </div>
+                        </div>
+
+                        <!-- Escritura -->
+                        <div class="category-card cursor-pointer" data-category="escritura">
+                            <div class="rounded-t-lg p-6 flex flex-col items-center justify-center h-40">
+                                <i class="fas fa-pen-fancy text-6xl text-rose-600 mb-2 category-icon"></i>
+                                <h4 class="text-xl font-bold text-gray-800">Escritura</h4>
+                            </div>
+                            <div class="bg-gradient-to-b from-white/50 to-white/30 rounded-b-lg p-3">
+                                <p class="text-sm text-gray-700 text-center font-semibold">10 recursos</p>
+                            </div>
+                        </div>
+
+                        <!-- Formación -->
+                        <div class="category-card cursor-pointer" data-category="formacion">
+                            <div class="rounded-t-lg p-6 flex flex-col items-center justify-center h-40">
+                                <i class="fas fa-graduation-cap text-6xl text-indigo-600 mb-2 category-icon"></i>
+                                <h4 class="text-xl font-bold text-gray-800">Formación</h4>
+                            </div>
+                            <div class="bg-gradient-to-b from-white/50 to-white/30 rounded-b-lg p-3">
+                                <p class="text-sm text-gray-700 text-center font-semibold">11 recursos</p>
+                            </div>
+                        </div>
+
+                        <!-- Productividad -->
+                        <div class="category-card cursor-pointer" data-category="productividad">
+                            <div class="rounded-t-lg p-6 flex flex-col items-center justify-center h-40">
+                                <i class="fas fa-tasks text-6xl text-sky-600 mb-2 category-icon"></i>
+                                <h4 class="text-xl font-bold text-gray-800">Productividad</h4>
+                            </div>
+                            <div class="bg-gradient-to-b from-white/50 to-white/30 rounded-b-lg p-3">
+                                <p class="text-sm text-gray-700 text-center font-semibold">10 recursos</p>
+                            </div>
+                        </div>
+
+                        <!-- Empleo -->
+                        <div class="category-card cursor-pointer" data-category="empleo">
+                            <div class="rounded-t-lg p-6 flex flex-col items-center justify-center h-40">
+                                <i class="fas fa-briefcase text-6xl text-slate-600 mb-2 category-icon"></i>
+                                <h4 class="text-xl font-bold text-gray-800">Empleo</h4>
+                            </div>
+                            <div class="bg-gradient-to-b from-white/50 to-white/30 rounded-b-lg p-3">
+                                <p class="text-sm text-gray-700 text-center font-semibold">10 recursos</p>
+                            </div>
+                        </div>
+
+                        <!-- Marketing -->
+                        <div class="category-card cursor-pointer" data-category="marketing">
+                            <div class="rounded-t-lg p-6 flex flex-col items-center justify-center h-40">
+                                <i class="fas fa-bullhorn text-6xl text-fuchsia-600 mb-2 category-icon"></i>
+                                <h4 class="text-xl font-bold text-gray-800">Marketing</h4>
+                            </div>
+                            <div class="bg-gradient-to-b from-white/50 to-white/30 rounded-b-lg p-3">
+                                <p class="text-sm text-gray-700 text-center font-semibold">11 recursos</p>
+                            </div>
+                        </div>
+
+                        <!-- Diseño -->
+                        <div class="category-card cursor-pointer" data-category="diseno">
+                            <div class="rounded-t-lg p-6 flex flex-col items-center justify-center h-40">
+                                <i class="fas fa-palette text-6xl text-violet-600 mb-2 category-icon"></i>
+                                <h4 class="text-xl font-bold text-gray-800">Diseño</h4>
+                            </div>
+                            <div class="bg-gradient-to-b from-white/50 to-white/30 rounded-b-lg p-3">
+                                <p class="text-sm text-gray-700 text-center font-semibold">11 recursos</p>
+                            </div>
+                        </div>
+
+                        <!-- Programación -->
+                        <div class="category-card cursor-pointer" data-category="programacion">
+                            <div class="rounded-t-lg p-6 flex flex-col items-center justify-center h-40">
+                                <i class="fas fa-laptop-code text-6xl text-lime-600 mb-2 category-icon"></i>
+                                <h4 class="text-xl font-bold text-gray-800">Programación</h4>
+                            </div>
+                            <div class="bg-gradient-to-b from-white/50 to-white/30 rounded-b-lg p-3">
+                                <p class="text-sm text-gray-700 text-center font-semibold">10 recursos</p>
+                            </div>
+                        </div>
+
+                    </div>
+
+                    <!-- Contenedor de enlaces por categoría (ocultos inicialmente) -->
+                    <div id="category-links-container" class="hidden">
+                        <button id="back-to-categories" class="neumorph-button mb-6 px-6 py-3 text-gray-700 font-semibold flex items-center gap-2">
+                            <i class="fas fa-arrow-left"></i> Volver a Categorías
+                        </button>
+
+                        <div id="category-title" class="text-2xl font-bold mb-6"></div>
+
+                        <!-- Mapas -->
+                        <div id="links-mapas" class="category-links hidden">
+                            <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <a href="https://comparamapas.navarra.es/?lang=es" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-map-location-dot text-2xl text-green-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Comparador Mapas Navarra</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Visualiza y compara diferentes mapas y ortofotos de la región de Navarra.</p>
+                                </a>
+                                <a href="https://idena.navarra.es/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-database text-2xl text-blue-800 link-icon"></i><h4 class="font-bold text-lg text-gray-800">IDENA</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Infraestructura de Datos Espaciales de Navarra. Cartografía y datos geográficos.</p>
+                                </a>
+                                <a href="https://visgl.github.io/react-google-maps/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-map-marked-alt text-2xl text-red-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">React Google Maps</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Componentes de React para integrar Google Maps en tus aplicaciones.</p>
+                                </a>
+                                <a href="https://cesium.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-globe-europe text-2xl text-blue-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Cesium</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Plataforma open source para crear aplicaciones geoespaciales 3D y gemelos digitales.</p>
+                                </a>
+                                <a href="https://s2maps.eu/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-satellite text-2xl text-indigo-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">S2 Maps</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Mapas satelitales de Europa basados en imágenes Sentinel-2 de alta resolución.</p>
+                                </a>
+                                <a href="https://www.3dstreet.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-road text-2xl text-amber-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">3D Street</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Herramienta para crear escenas urbanas 3D y combinarlas con mapas interactivos.</p>
+                                </a>
+                                <a href="https://earth.google.com/web/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-earth-americas text-2xl text-blue-400 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Google Earth Web</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Explora el mundo en 3D con imágenes satelitales y Street View desde el navegador.</p>
+                                </a>
+                                <a href="https://pcsitna.navarra.es/es/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-layer-group text-2xl text-teal-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">SITNA - Navarra</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Sistema de Información Territorial de Navarra con cartografía oficial.</p>
+                                </a>
+                                <a href="https://www.maptiler.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-map text-2xl text-orange-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">MapTiler</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Crea mapas personalizados con estilos únicos y APIs para desarrolladores.</p>
+                                </a>
+                                <a href="https://developers.arcgis.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-code text-2xl text-purple-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">ArcGIS Developers</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">APIs y SDKs de Esri para desarrollar aplicaciones de mapas y análisis espacial.</p>
+                                </a>
+                                <a href="https://app.topoexport.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-mountain text-2xl text-emerald-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">TopoExport</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Exporta mapas topográficos de alta calidad para senderismo y actividades outdoor.</p>
+                                </a>
+                                <a href="https://www.scne.es/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-compass text-2xl text-cyan-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">SCNE - Sistema Cartográfico</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Sistema Cartográfico Nacional de España con datos geográficos oficiales.</p>
+                                </a>
+                                <a href="https://www.csg-cnc.es/mapaciudadano.html" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-users text-2xl text-rose-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Mapa Ciudadano</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Plataforma colaborativa de cartografía ciudadana del Centro Nacional de Geografía.</p>
+                                </a>
+                                <a href="https://ideespain.github.io/mapabase/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-vector-square text-2xl text-lime-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">MapaBase España</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Mapa base de España para visualización de infraestructuras de datos espaciales.</p>
+                                </a>
+                                <a href="https://lidar.navarra.es/data/view.html" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-wave-square text-2xl text-violet-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">LiDAR Navarra</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Visualizador de datos LiDAR de Navarra con modelos digitales de elevación.</p>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- IAs -->
+                        <div id="links-ias" class="category-links hidden">
+                            <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <a href="https://aistudio.google.com/prompts/new_chat" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-robot text-2xl text-blue-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Google AI Studio</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Experimenta y crea con los modelos de inteligencia artificial de Google.</p>
+                                </a>
+                                <a href="https://openai.com/es-ES/gpt-5/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-brain text-2xl text-teal-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">ChatGPT 5</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Accede a los modelos de lenguaje avanzados de OpenAI para tareas de IA.</p>
+                                </a>
+                                <a href="https://www.anthropic.com/claude/sonnet" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-microchip text-2xl text-violet-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Claude Sonnet 4</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Modelo de IA de Anthropic para programación y razonamiento complejo.</p>
+                                </a>
+                                <a href="https://www.midjourney.com/home" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-paint-brush text-2xl text-indigo-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Midjourney</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Generador de imágenes a partir de texto mediante inteligencia artificial.</p>
+                                </a>
+                                <a href="https://gamma.app/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-presentation text-2xl text-yellow-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Gamma</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Crea presentaciones, documentos y webs con IA de forma instantánea.</p>
+                                </a>
+                                <a href="https://runwayml.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-film text-2xl text-green-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Runway ML</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Edición de vídeo potenciada por IA, generación y efectos creativos.</p>
+                                </a>
+                                <a href="https://www.perplexity.ai/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-search text-2xl text-blue-400 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Perplexity AI</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Motor de búsqueda con IA que responde preguntas con fuentes citadas.</p>
+                                </a>
+                                <a href="https://www.synthesia.io/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-user-circle text-2xl text-pink-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Synthesia</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Crea vídeos con avatares de IA a partir de texto en minutos.</p>
+                                </a>
+                                <a href="https://elevenlabs.io/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-volume-up text-2xl text-orange-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">ElevenLabs</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Generación de voz con IA realista, clonación y texto a voz.</p>
+                                </a>
+                                <a href="https://scribehow.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-book-open text-2xl text-cyan-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Scribe</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Genera documentación y guías paso a paso automáticamente.</p>
+                                </a>
+                                <a href="https://durable.co/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-globe text-2xl text-purple-400 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Durable</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Constructor de sitios web con IA que crea tu web en segundos.</p>
+                                </a>
+                                <a href="https://murf.ai/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-microphone-alt text-2xl text-red-400 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Murf AI</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Voiceovers profesionales con IA para vídeos, podcasts y más.</p>
+                                </a>
+                                <a href="https://theresanaiforthat.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-wand-magic-sparkles text-2xl text-pink-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">There's An AI For That</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Directorio con miles de herramientas de IA categorizadas para cada tarea.</p>
+                                </a>
+                                <a href="https://www.dorkgpt.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-magnifying-glass-chart text-2xl text-emerald-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">DorkGPT</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Genera Google Dorks con IA para búsquedas avanzadas y OSINT.</p>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Esquemas -->
+                        <div id="links-esquemas" class="category-links hidden">
+                            <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <a href="https://app.diagrams.net/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-project-diagram text-2xl text-yellow-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Diagrams.net</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Herramienta gratuita para crear diagramas de flujo, mapas mentales y más.</p>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Developing -->
+                        <div id="links-developing" class="category-links hidden">
+                            <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <a href="https://vercel.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-server text-2xl text-gray-800 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Vercel</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Plataforma de hosting para desplegar aplicaciones web modernas y rápidas.</p>
+                                </a>
+                                <a href="https://astro.build/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-rocket text-2xl text-orange-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Astro</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Framework web para construir sitios rápidos y centrados en el contenido.</p>
+                                </a>
+                                <a href="https://supabase.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-bolt text-2xl text-green-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Supabase</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Alternativa a Firebase con base de datos, autenticación y más.</p>
+                                </a>
+                                <a href="https://pnpm.io/es/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-box-open text-2xl text-yellow-400 link-icon"></i><h4 class="font-bold text-lg text-gray-800">pnpm</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Gestor de paquetes rápido y eficiente en el uso de disco para JavaScript.</p>
+                                </a>
+                                <a href="https://windsurf.com/editor" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-code text-2xl text-sky-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Windsurf Editor</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Editor de código colaborativo en tiempo real para desarrollo en equipo.</p>
+                                </a>
+                                <a href="https://www.cloudflare.com/es-es/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-shield-halved text-2xl text-orange-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Cloudflare</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Servicios de seguridad, rendimiento y CDN para sitios y aplicaciones web.</p>
+                                </a>
+                                <a href="https://www.radix-ui.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-cubes text-2xl text-gray-900 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Radix UI</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Componentes de interfaz de usuario de bajo nivel para aplicaciones React.</p>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Blogs -->
+                        <div id="links-blogs" class="category-links hidden">
+                            <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <a href="https://www.theunwindai.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-newspaper text-2xl text-blue-400 link-icon"></i><h4 class="font-bold text-lg text-gray-800">The Unwind AI</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Newsletter y recursos para mantenerse al día con la inteligencia artificial.</p>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Multimedia -->
+                        <div id="links-multimedia" class="category-links hidden">
+                            <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <a href="https://tinywow.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-toolbox text-2xl text-orange-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">TinyWow</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Herramientas online gratuitas para PDF, imágenes, vídeos y más.</p>
+                                </a>
+                                <a href="https://mega.nz/folder/Uc4U3KpL#uzR3-BaRzcS9DZNo3nAxaw/folder/5RJQQLwD" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-cloud text-2xl text-red-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Almacenamiento Nube</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Accede a una carpeta compartida con archivos y recursos.</p>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Seguridad -->
+                        <div id="links-seguridad" class="category-links hidden">
+                            <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <a href="https://www.surveillancewatch.io/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-video text-2xl text-gray-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">SurveillanceWatch</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Monitoriza y recibe alertas sobre vulnerabilidades de seguridad.</p>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Curiosidades -->
+                        <div id="links-curiosidades" class="category-links hidden">
+                            <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <a href="https://alison.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-graduation-cap text-2xl text-purple-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Alison</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Plataforma de aprendizaje con miles de cursos online gratuitos.</p>
+                                </a>
+                                <a href="https://visualgo.net/en" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-shapes text-2xl text-lime-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">VisuAlgo</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Visualiza algoritmos y estructuras de datos de forma interactiva.</p>
+                                </a>
+                                <a href="https://stan-smith.github.io/FossFLOW/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-sitemap text-2xl text-cyan-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">FossFLOW</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Visualizador de flujos de trabajo de código abierto para análisis de datos.</p>
+                                </a>
+                                <a href="https://posthog.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-chart-line text-2xl text-yellow-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">PostHog</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Plataforma de análisis de productos y datos para desarrolladores.</p>
+                                </a>
+                                <a href="https://www.firecrawl.dev/pricing" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-spider text-2xl text-red-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Firecrawl</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">API para rastrear y convertir sitios web en datos estructurados y fiables.</p>
+                                </a>
+                                <a href="https://animagraffs.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-gears text-2xl text-orange-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Animagraffs</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Infografías animadas que explican cómo funcionan motores, armas y máquinas.</p>
+                                </a>
+                                <a href="https://pointerpointer.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-hand-pointer text-2xl text-blue-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Pointer Pointer</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Web curiosa que muestra fotos de personas apuntando exactamente donde está tu cursor.</p>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Herramientas -->
+                        <div id="links-herramientas" class="category-links hidden">
+                            <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <a href="https://tinyurl.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-link text-2xl text-amber-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">TinyURL</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Acorta enlaces largos en URLs cortas y fáciles de compartir.</p>
+                                </a>
+                                <a href="https://www.pdfescape.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-file-pdf text-2xl text-red-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">PDFescape</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Edita archivos PDF online de forma gratuita sin instalar software.</p>
+                                </a>
+                                <a href="https://cloudconvert.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-exchange-alt text-2xl text-blue-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">CloudConvert</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Convierte archivos entre más de 200 formatos diferentes online.</p>
+                                </a>
+                                <a href="https://wetransfer.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-paper-plane text-2xl text-cyan-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">WeTransfer</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Envía archivos grandes de hasta 2GB de forma gratuita y sencilla.</p>
+                                </a>
+                                <a href="https://www.unscreen.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-video text-2xl text-purple-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Unscreen</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Elimina el fondo de vídeos automáticamente con IA.</p>
+                                </a>
+                                <a href="https://smallpdf.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-file-alt text-2xl text-red-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">SmallPDF</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Suite completa de herramientas PDF: comprimir, convertir, editar y más.</p>
+                                </a>
+                                <a href="https://web.archive.org/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-history text-2xl text-gray-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Wayback Machine</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Accede a versiones antiguas de cualquier sitio web archivado.</p>
+                                </a>
+                                <a href="https://getsharex.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-camera text-2xl text-teal-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">ShareX</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Herramienta gratuita de captura de pantalla y grabación de vídeo.</p>
+                                </a>
+                                <a href="https://temp-mail.org/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-envelope text-2xl text-orange-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">TempMail</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Genera emails temporales desechables para registros y pruebas.</p>
+                                </a>
+                                <a href="https://downforeveryoneorjustme.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-server text-2xl text-green-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Down For Everyone</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Comprueba si un sitio web está caído para todos o solo para ti.</p>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Finanzas -->
+                        <div id="links-finanzas" class="category-links hidden">
+                            <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <a href="https://www.tradingview.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-chart-line text-2xl text-blue-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">TradingView</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Gráficos financieros avanzados y análisis técnico en tiempo real.</p>
+                                </a>
+                                <a href="https://www.moneycontrol.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-newspaper text-2xl text-red-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">MoneyControl</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Noticias financieras, cotizaciones y análisis de mercados.</p>
+                                </a>
+                                <a href="https://mint.intuit.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-wallet text-2xl text-green-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Mint</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Rastrea tus finanzas personales, gastos y presupuestos en un solo lugar.</p>
+                                </a>
+                                <a href="https://www.ynab.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-piggy-bank text-2xl text-cyan-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">YNAB</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Planificador de presupuestos que te ayuda a controlar cada euro.</p>
+                                </a>
+                                <a href="https://coinmarketcap.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fab fa-bitcoin text-2xl text-yellow-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">CoinMarketCap</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Precios de criptomonedas, capitalización de mercado y rankings.</p>
+                                </a>
+                                <a href="https://www.investopedia.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-book text-2xl text-purple-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Investopedia</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Educación financiera, diccionario de términos y tutoriales de inversión.</p>
+                                </a>
+                                <a href="https://cleartax.in/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-file-invoice-dollar text-2xl text-teal-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">ClearTax</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Presenta tus impuestos online de forma fácil y rápida.</p>
+                                </a>
+                                <a href="https://groww.in/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-seedling text-2xl text-green-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Groww</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">App de inversión para acciones, fondos mutuos y más.</p>
+                                </a>
+                                <a href="https://www.paypal.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fab fa-paypal text-2xl text-blue-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">PayPal</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Pagos online seguros, envía y recibe dinero en todo el mundo.</p>
+                                </a>
+                                <a href="https://wise.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-globe text-2xl text-green-400 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Wise</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Transferencias internacionales con tipo de cambio real y bajas comisiones.</p>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Escritura -->
+                        <div id="links-escritura" class="category-links hidden">
+                            <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <a href="https://www.grammarly.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-spell-check text-2xl text-green-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Grammarly</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Corrector gramatical y de estilo con IA para mejorar tu escritura.</p>
+                                </a>
+                                <a href="https://hemingwayapp.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-pencil-alt text-2xl text-yellow-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Hemingway App</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Mejora la claridad de tu escritura identificando frases complejas.</p>
+                                </a>
+                                <a href="https://prowritingaid.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-edit text-2xl text-blue-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">ProWritingAid</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Editor de escritura con análisis de estilo, gramática y legibilidad.</p>
+                                </a>
+                                <a href="https://quillbot.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-sync-alt text-2xl text-teal-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">QuillBot</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Herramienta de parafraseo con IA para reescribir textos.</p>
+                                </a>
+                                <a href="https://www.wordtune.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-magic text-2xl text-purple-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Wordtune</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Reescribe oraciones con sugerencias de IA para mejorar tu texto.</p>
+                                </a>
+                                <a href="https://www.readsy.co/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-tachometer-alt text-2xl text-orange-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Readsy</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Entrena tu velocidad de lectura con técnicas de lectura rápida.</p>
+                                </a>
+                                <a href="https://www.airstory.co/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-feather-alt text-2xl text-indigo-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Airstory</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Herramienta de investigación y escritura para crear contenido.</p>
+                                </a>
+                                <a href="https://coschedule.com/headline-analyzer" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-heading text-2xl text-red-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Headline Analyzer</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Analiza y puntúa tus titulares para maximizar el engagement.</p>
+                                </a>
+                                <a href="https://www.clichefinder.net/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-search text-2xl text-gray-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Cliché Finder</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Detecta y elimina clichés de tu escritura para textos más originales.</p>
+                                </a>
+                                <a href="https://www.canirank.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-chart-bar text-2xl text-cyan-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">CanIRank</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Analiza el SEO de tu contenido y mejora tu ranking en buscadores.</p>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Formación -->
+                        <div id="links-formacion" class="category-links hidden">
+                            <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <a href="https://www.coursera.org/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-university text-2xl text-blue-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Coursera</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Cursos universitarios online de las mejores instituciones del mundo.</p>
+                                </a>
+                                <a href="https://www.skillshare.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-palette text-2xl text-green-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Skillshare</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Clases de habilidades creativas y profesionales basadas en proyectos.</p>
+                                </a>
+                                <a href="https://www.khanacademy.org/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-chalkboard-teacher text-2xl text-teal-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Khan Academy</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Educación gratuita de alta calidad en matemáticas, ciencias y más.</p>
+                                </a>
+                                <a href="https://www.mindtools.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-brain text-2xl text-purple-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">MindTools</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Recursos para desarrollo de habilidades profesionales y liderazgo.</p>
+                                </a>
+                                <a href="https://www.ted.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-microphone text-2xl text-red-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">TED</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Charlas inspiradoras de expertos sobre tecnología, ciencia y más.</p>
+                                </a>
+                                <a href="https://www.udemy.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-play-circle text-2xl text-pink-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Udemy</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Miles de cursos asequibles en programación, negocios, diseño y más.</p>
+                                </a>
+                                <a href="https://www.duolingo.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-language text-2xl text-green-400 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Duolingo</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Aprende idiomas gratis de forma divertida y gamificada.</p>
+                                </a>
+                                <a href="https://www.futurelearn.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-graduation-cap text-2xl text-indigo-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">FutureLearn</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Cursos cortos gratuitos de universidades y organizaciones líderes.</p>
+                                </a>
+                                <a href="https://brilliant.org/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-lightbulb text-2xl text-yellow-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Brilliant</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Aprende matemáticas y ciencias resolviendo problemas interactivos.</p>
+                                </a>
+                                <a href="https://www.edx.org/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-book-reader text-2xl text-blue-700 link-icon"></i><h4 class="font-bold text-lg text-gray-800">edX</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Cursos de nivel universitario de Harvard, MIT y otras instituciones.</p>
+                                </a>
+                                <a href="https://phet.colorado.edu/es/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-flask text-2xl text-orange-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">PhET Simulaciones</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Simulaciones interactivas gratuitas de física, química, matemáticas y ciencias.</p>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Productividad -->
+                        <div id="links-productividad" class="category-links hidden">
+                            <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <a href="https://www.notion.so/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-cube text-2xl text-gray-800 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Notion</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Espacio de trabajo todo en uno para notas, proyectos y bases de datos.</p>
+                                </a>
+                                <a href="https://trello.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fab fa-trello text-2xl text-blue-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Trello</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Tableros Kanban visuales para gestionar tareas y proyectos en equipo.</p>
+                                </a>
+                                <a href="https://todoist.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-check-circle text-2xl text-red-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Todoist</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Gestor de tareas potente y minimalista para organizar tu vida.</p>
+                                </a>
+                                <a href="https://www.rescuetime.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-clock text-2xl text-blue-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">RescueTime</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Rastrea automáticamente tu tiempo y mejora tu enfoque y productividad.</p>
+                                </a>
+                                <a href="https://clockify.me/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-stopwatch text-2xl text-cyan-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Clockify</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Rastreador de tiempo gratuito para equipos y freelancers.</p>
+                                </a>
+                                <a href="https://pomofocus.io/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-hourglass-half text-2xl text-red-400 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Pomofocus</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Temporizador Pomodoro online para mejorar tu concentración.</p>
+                                </a>
+                                <a href="https://miro.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-chalkboard text-2xl text-yellow-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Miro</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Pizarra colaborativa online para brainstorming y trabajo en equipo.</p>
+                                </a>
+                                <a href="https://keep.google.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-sticky-note text-2xl text-yellow-400 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Google Keep</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Notas simples y rápidas sincronizadas con tu cuenta de Google.</p>
+                                </a>
+                                <a href="https://evernote.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-elephant text-2xl text-green-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Evernote</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">App de notas avanzada para capturar y organizar ideas.</p>
+                                </a>
+                                <a href="https://www.loom.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-video text-2xl text-purple-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Loom</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Graba y comparte vídeos rápidos para comunicación asíncrona.</p>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Empleo -->
+                        <div id="links-empleo" class="category-links hidden">
+                            <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <a href="https://www.linkedin.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fab fa-linkedin text-2xl text-blue-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">LinkedIn</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Red profesional para networking, búsqueda de empleo y conexiones.</p>
+                                </a>
+                                <a href="https://www.indeed.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-search text-2xl text-blue-700 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Indeed</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Motor de búsqueda de empleo con millones de ofertas en todo el mundo.</p>
+                                </a>
+                                <a href="https://www.glassdoor.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-building text-2xl text-green-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Glassdoor</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Reviews de empresas, salarios y entrevistas de empleados reales.</p>
+                                </a>
+                                <a href="https://internshala.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-user-graduate text-2xl text-blue-400 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Internshala</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Plataforma de prácticas y formación para estudiantes.</p>
+                                </a>
+                                <a href="https://angel.co/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-rocket text-2xl text-gray-700 link-icon"></i><h4 class="font-bold text-lg text-gray-800">AngelList</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Empleos en startups y oportunidades de inversión en nuevas empresas.</p>
+                                </a>
+                                <a href="https://www.naukri.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-briefcase text-2xl text-blue-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Naukri</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Portal de empleo líder con ofertas de trabajo diversas.</p>
+                                </a>
+                                <a href="https://wellfound.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-lightbulb text-2xl text-orange-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Wellfound</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Plataforma de contratación para startups tecnológicas.</p>
+                                </a>
+                                <a href="https://www.flexjobs.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-home text-2xl text-teal-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">FlexJobs</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Trabajos remotos y flexibles verificados sin estafas.</p>
+                                </a>
+                                <a href="https://www.levels.fyi/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-chart-bar text-2xl text-purple-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Levels.fyi</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Compara salarios y niveles de carrera en empresas tech.</p>
+                                </a>
+                                <a href="https://www.jobscan.co/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-file-alt text-2xl text-cyan-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Jobscan</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Optimiza tu CV para sistemas ATS y aumenta tus oportunidades.</p>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Marketing -->
+                        <div id="links-marketing" class="category-links hidden">
+                            <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <a href="https://www.hubspot.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fab fa-hubspot text-2xl text-orange-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">HubSpot</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">CRM gratuito con guías de marketing, ventas y servicio al cliente.</p>
+                                </a>
+                                <a href="https://buffer.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-share-alt text-2xl text-blue-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Buffer</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Programa y publica contenido en redes sociales fácilmente.</p>
+                                </a>
+                                <a href="https://neilpatel.com/ubersuggest/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-search-dollar text-2xl text-green-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Ubersuggest</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Herramienta SEO gratuita para palabras clave y análisis de competencia.</p>
+                                </a>
+                                <a href="https://answerthepublic.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-question-circle text-2xl text-yellow-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">AnswerThePublic</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Descubre qué preguntas hace la gente sobre cualquier tema.</p>
+                                </a>
+                                <a href="https://mailchimp.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fab fa-mailchimp text-2xl text-yellow-400 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Mailchimp</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Plataforma de email marketing para crear y enviar newsletters.</p>
+                                </a>
+                                <a href="https://www.hootsuite.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-owl text-2xl text-gray-700 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Hootsuite</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Gestiona todas tus redes sociales desde un solo panel.</p>
+                                </a>
+                                <a href="https://buzzsumo.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-fire text-2xl text-red-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">BuzzSumo</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Analiza contenido viral y encuentra influencers en tu nicho.</p>
+                                </a>
+                                <a href="https://www.copy.ai/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-robot text-2xl text-purple-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Copy.ai</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Genera textos de marketing con IA para anuncios, emails y más.</p>
+                                </a>
+                                <a href="https://bitly.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-link text-2xl text-orange-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Bitly</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Acorta URLs y rastrea clics con analíticas detalladas.</p>
+                                </a>
+                                <a href="https://trends.google.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fab fa-google text-2xl text-blue-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Google Trends</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Descubre tendencias de búsqueda y temas populares en tiempo real.</p>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Diseño -->
+                        <div id="links-diseno" class="category-links hidden">
+                            <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <a href="https://www.figma.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fab fa-figma text-2xl text-purple-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Figma</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Herramienta de diseño UI/UX colaborativa en el navegador.</p>
+                                </a>
+                                <a href="https://www.canva.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-paint-brush text-2xl text-cyan-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Canva</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Diseño gráfico fácil para todos con plantillas profesionales.</p>
+                                </a>
+                                <a href="https://coolors.co/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-palette text-2xl text-pink-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Coolors</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Generador de paletas de colores rápido y elegante.</p>
+                                </a>
+                                <a href="https://unsplash.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-image text-2xl text-gray-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Unsplash</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Fotos de alta calidad gratuitas para usar en cualquier proyecto.</p>
+                                </a>
+                                <a href="https://www.flaticon.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-icons text-2xl text-teal-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Flaticon</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Base de datos masiva de iconos gratuitos en múltiples formatos.</p>
+                                </a>
+                                <a href="https://dribbble.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fab fa-dribbble text-2xl text-pink-400 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Dribbble</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Comunidad de diseñadores con inspiración y portfolios creativos.</p>
+                                </a>
+                                <a href="https://www.behance.net/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fab fa-behance text-2xl text-blue-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Behance</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Portfolios creativos y proyectos de diseñadores profesionales.</p>
+                                </a>
+                                <a href="https://www.remove.bg/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-eraser text-2xl text-green-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Remove.bg</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Elimina el fondo de imágenes automáticamente con un clic.</p>
+                                </a>
+                                <a href="https://spline.design/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-cube text-2xl text-indigo-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Spline</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Diseño 3D colaborativo para web con animaciones interactivas.</p>
+                                </a>
+                                <a href="https://ui8.net/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-layer-group text-2xl text-yellow-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">UI8</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Assets de diseño premium: kits UI, iconos, ilustraciones y más.</p>
+                                </a>
+                                <a href="https://3dwarehouse.sketchup.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-cubes text-2xl text-red-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">3D Warehouse</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Biblioteca de modelos 3D gratuitos de SketchUp para arquitectura y diseño.</p>
+                                </a>
+                            </div>
+                        </div>
+
+                        <!-- Programación -->
+                        <div id="links-programacion" class="category-links hidden">
+                            <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                                <a href="https://www.freecodecamp.org/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fab fa-free-code-camp text-2xl text-green-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">freeCodeCamp</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Aprende a programar gratis con proyectos prácticos y certificaciones.</p>
+                                </a>
+                                <a href="https://www.w3schools.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-graduation-cap text-2xl text-green-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">W3Schools</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Tutoriales fáciles de HTML, CSS, JavaScript y más lenguajes.</p>
+                                </a>
+                                <a href="https://www.codecademy.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-laptop-code text-2xl text-blue-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Codecademy</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Lecciones interactivas de programación con práctica en tiempo real.</p>
+                                </a>
+                                <a href="https://codehype.in/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-fire-alt text-2xl text-orange-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">CodeHype</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Recursos gratuitos de aprendizaje para desarrolladores.</p>
+                                </a>
+                                <a href="https://www.geeksforgeeks.org/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-code text-2xl text-green-700 link-icon"></i><h4 class="font-bold text-lg text-gray-800">GeeksforGeeks</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Tutoriales de algoritmos, estructuras de datos y preparación para entrevistas.</p>
+                                </a>
+                                <a href="https://cs50.harvard.edu/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-university text-2xl text-red-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">CS50 Harvard</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Curso gratuito de introducción a la informática de Harvard.</p>
+                                </a>
+                                <a href="https://leetcode.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-terminal text-2xl text-yellow-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">LeetCode</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Practica problemas de algoritmos para entrevistas técnicas.</p>
+                                </a>
+                                <a href="https://exercism.org/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-dumbbell text-2xl text-purple-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Exercism</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Ejercicios prácticos con mentoría en más de 60 lenguajes.</p>
+                                </a>
+                                <a href="https://www.sololearn.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-mobile-alt text-2xl text-pink-500 link-icon"></i><h4 class="font-bold text-lg text-gray-800">SoloLearn</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Aprende a programar desde tu móvil con lecciones cortas.</p>
+                                </a>
+                                <a href="https://www.programiz.com/" target="_blank" class="link-card-neumorph block">
+                                    <div class="flex items-center gap-3"><i class="fas fa-book-open text-2xl text-blue-600 link-icon"></i><h4 class="font-bold text-lg text-gray-800">Programiz</h4></div>
+                                    <p class="text-sm text-gray-600 mt-2">Guías para principiantes de Python, C, Java y más lenguajes.</p>
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+            </section>
         </main>
     </div>
 
@@ -887,6 +1754,53 @@
 
             // Verificar estado al cargar la página
             updateAuthUI();
+
+            // Manejo de categorías de enlaces
+            const categoryCards = document.querySelectorAll('.category-card');
+            const categoryLinksContainer = document.getElementById('category-links-container');
+            const backToCategoriesBtn = document.getElementById('back-to-categories');
+            const categoryTitle = document.getElementById('category-title');
+            const categoryGrid = document.querySelector('#enlaces-content .grid.sm\\:grid-cols-2.lg\\:grid-cols-4');
+
+            const categoryNames = {
+                'mapas': 'Mapas',
+                'ias': 'Inteligencia Artificial',
+                'esquemas': 'Esquemas',
+                'developing': 'Desarrollo Web',
+                'blogs': 'Blogs',
+                'multimedia': 'Multimedia',
+                'seguridad': 'Seguridad',
+                'curiosidades': 'Curiosidades',
+                'herramientas': 'Herramientas',
+                'finanzas': 'Finanzas',
+                'escritura': 'Escritura',
+                'formacion': 'Formación',
+                'productividad': 'Productividad',
+                'empleo': 'Empleo',
+                'marketing': 'Marketing',
+                'diseno': 'Diseño',
+                'programacion': 'Programación'
+            };
+
+            categoryCards.forEach(card => {
+                card.addEventListener('click', () => {
+                    const category = card.dataset.category;
+                    if (categoryGrid) categoryGrid.style.display = 'none';
+                    if (categoryLinksContainer) categoryLinksContainer.classList.remove('hidden');
+                    if (categoryTitle) categoryTitle.textContent = categoryNames[category] || category;
+                    document.querySelectorAll('.category-links').forEach(links => links.classList.add('hidden'));
+                    const selectedLinks = document.getElementById(`links-${category}`);
+                    if (selectedLinks) selectedLinks.classList.remove('hidden');
+                });
+            });
+
+            if (backToCategoriesBtn) {
+                backToCategoriesBtn.addEventListener('click', () => {
+                    if (categoryLinksContainer) categoryLinksContainer.classList.add('hidden');
+                    if (categoryGrid) categoryGrid.style.display = 'grid';
+                    document.querySelectorAll('.category-links').forEach(links => links.classList.add('hidden'));
+                });
+            }
         });
     </script>
 </body>


### PR DESCRIPTION
Recupera el contenido de #enlaces-content (vacío desde commit 18ed360) a partir del último estado válido en 048e454. Incluye:

- 17 tarjetas de categoría (Mapas, IAs, Esquemas, Developing, Blogs, Multimedia, Seguridad, Curiosidades, Herramientas, Finanzas, Escritura, Formación, Productividad, Empleo, Marketing, Diseño, Programación)
- 140 enlaces distribuidos en las categorías
- Handler JS para navegación categoría → enlaces → volver
- Diccionario categoryNames completo con las 17 entradas (antes solo 8)