### PR TITLE
Apunta la tarjeta de Red Hogar a su despliegue en Vercel

### DIFF
--- a/index.html
+++ b/index.html
@@ -683,7 +683,7 @@
                     </article>
                     </a>
 
-                    <a href="https://github.com/Rubenpantxo/red-hogar-" target="_blank" rel="noopener noreferrer" class="block private-app"><span class="app-lock">🔒</span>
+                    <a href="https://red-hogar.vercel.app/" target="_blank" rel="noopener noreferrer" class="block private-app"><span class="app-lock">🔒</span>
                     <article class="bg-white rounded-lg shadow-md p-4 flex items-center gap-3 hover:shadow-lg transition-shadow cursor-pointer">
                         <div class="w-12 h-12 bg-rose-50 rounded-lg flex items-center justify-center text-3xl">📡</div>
                         <div>


### PR DESCRIPTION
## Contexto

La app **Red Hogar** ya se migró a su repositorio privado y se desplegó en Vercel (la eliminación de `apps/red-hogar/` del repo público se hizo en el PR #99, ya fusionado). La app en producción está en https://red-hogar.vercel.app/, protegida por la misma contraseña de la zona privada.

Tras aquel PR, la tarjeta de la portada apuntaba todavía al repositorio de GitHub. Este PR la deja apuntando a la app en Vercel.

## Cambios

- **Reapunta** la tarjeta privada 🔒 de «Red Hogar» en la portada (`index.html`): de `github.com/Rubenpantxo/red-hogar-` a `https://red-hogar.vercel.app/`, abriéndose en una pestaña nueva.

Diff de una sola línea, sin conflictos con `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U4xUmpdJ9fFbmpVQNieuPJ