### PR TITLE
Ajedrez 3D: cargar partida desde imagen del tablero

### DIFF
--- a/juegos/Chess3D/README.md
+++ b/juegos/Chess3D/README.md
@@ -24,7 +24,9 @@ Modos de juego
 - **Dos jugadores** — partida local en el mismo tablero.
 - **Ráfaga de mates** — 3 minutos y 3 vidas para encadenar tantos mates en 1
   como puedas. 64 puzzles validados por el motor y récord guardado en tu navegador.
-- **Cargar partida** — importa cualquier PGN y sigue jugando contra la IA.
+- **Cargar partida** — importa cualquier PGN, o **sube una imagen del tablero**
+  (PNG, JPG, JPEG…): se analiza en tu navegador para reconstruir la posición.
+  Un editor te deja corregir cualquier casilla antes de seguir jugando contra la IA.
 
 Características
 ---------------

--- a/juegos/Chess3D/css/style.css
+++ b/juegos/Chess3D/css/style.css
@@ -514,7 +514,8 @@ select {
 	transform: translateY(-3px);
 }
 
-/* PGN */
+/* PGN / cargar posicion */
+#modal-pgn { max-height: 92vh; overflow-y: auto; }
 #modal-pgn textarea {
 	width: min(420px, 80vw);
 	height: 160px;
@@ -529,6 +530,114 @@ select {
 	margin-bottom: 1em;
 }
 #modal-pgn input[type="file"] { color: var(--muted); margin-bottom: 1.2em; font-size: 0.85em; }
+
+/* fuentes de carga (PGN / imagen) */
+.load-sources {
+	display: flex;
+	gap: 10px;
+	justify-content: center;
+	flex-wrap: wrap;
+	margin-bottom: 0.4em;
+}
+.file-btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	padding: 9px 16px;
+	border: 1px solid var(--panel-border);
+	border-radius: 10px;
+	background: rgba(255,255,255,0.05);
+	color: var(--text);
+	font-size: 0.85em;
+	cursor: pointer;
+	transition: all 0.12s ease;
+}
+.file-btn:hover { border-color: var(--gold); background: rgba(216,185,140,0.12); }
+.file-btn input[type="file"] {
+	position: absolute;
+	width: 1px; height: 1px;
+	opacity: 0; overflow: hidden;
+	margin: 0; padding: 0;
+}
+
+/* editor de posicion detectada en imagen */
+#board-vision { margin-top: 1.1em; }
+#bv-status { color: var(--gold); font-size: 0.85em; margin-bottom: 0.8em; min-height: 1.1em; }
+#bv-editor {
+	display: flex;
+	gap: 16px;
+	justify-content: center;
+	align-items: flex-start;
+	flex-wrap: wrap;
+}
+#bv-board {
+	display: grid;
+	grid-template-columns: repeat(8, 1fr);
+	width: min(320px, 78vw);
+	aspect-ratio: 1 / 1;
+	border: 2px solid var(--gold);
+	border-radius: 6px;
+	overflow: hidden;
+}
+.bv-cell {
+	border: none;
+	padding: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: clamp(16px, 5.5vw, 30px);
+	line-height: 1;
+	aspect-ratio: 1 / 1;
+	transition: filter 0.1s ease;
+}
+.bv-cell.light { background: #e8d0a8; }
+.bv-cell.dark { background: #9a6b3f; }
+.bv-cell:hover { filter: brightness(1.12); }
+.bv-piece { pointer-events: none; }
+.bv-piece.white-piece { color: #fff; text-shadow: 0 0 2px #000, 0 1px 2px rgba(0,0,0,0.7); }
+.bv-piece.black-piece { color: #111; text-shadow: 0 0 2px rgba(255,255,255,0.35); }
+
+#bv-tools { display: flex; flex-direction: column; gap: 12px; }
+#bv-palette {
+	display: grid;
+	grid-template-columns: repeat(6, 1fr);
+	gap: 5px;
+	max-width: 230px;
+}
+.bv-brush {
+	width: 100%;
+	aspect-ratio: 1 / 1;
+	border: 1px solid var(--panel-border);
+	border-radius: 7px;
+	background: rgba(255,255,255,0.06);
+	font-size: clamp(15px, 4.5vw, 22px);
+	line-height: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--text);
+	transition: all 0.1s ease;
+}
+.bv-brush .white-piece { color: #fff; text-shadow: 0 0 2px #000; }
+.bv-brush .black-piece { color: #111; text-shadow: 0 0 2px rgba(255,255,255,0.4); }
+.bv-brush.erase { color: var(--muted); }
+.bv-brush:hover { border-color: var(--gold); }
+.bv-brush.active {
+	border-color: var(--gold-strong);
+	background: rgba(240,217,168,0.22);
+	box-shadow: 0 0 0 1px var(--gold-strong);
+}
+.bv-controls { display: flex; flex-direction: column; gap: 8px; }
+.bv-turn-label { color: var(--muted); font-size: 0.85em; display: flex; align-items: center; gap: 6px; }
+.bv-turn-label select {
+	background: #17110a;
+	color: var(--text);
+	border: 1px solid var(--panel-border);
+	border-radius: 6px;
+	padding: 4px 6px;
+}
+.bv-controls .btn { padding: 7px 10px; font-size: 0.82em; }
+.bv-hint { color: var(--muted); font-size: 0.78em; margin: 0.9em 0 0; }
 
 /* record de rafaga */
 #pz-end-record {

--- a/juegos/Chess3D/index.html
+++ b/juegos/Chess3D/index.html
@@ -41,7 +41,7 @@
       <button class="mode-card" id="card-load">
         <span class="icon">📂</span>
         <span class="name">Cargar partida</span>
-        <span class="desc">Continúa una partida guardada en formato PGN.</span>
+        <span class="desc">Desde un PGN o desde una imagen del tablero (PNG, JPG, JPEG…): la analizamos y copiamos la posición.</span>
       </button>
     </div>
 
@@ -165,10 +165,39 @@
 
   <div id="modal-pgn" class="modal hidden">
     <h2 class="draw">Cargar partida</h2>
-    <p>Pega un PGN o elige un archivo</p>
+    <p>Pega un PGN, o sube una imagen del tablero (PNG, JPG, JPEG…) y detectamos la posición.</p>
     <textarea id="pgn-text" spellcheck="false" placeholder="1. e4 e5 2. Nf3 ..."></textarea>
-    <br>
-    <input type="file" id="pgn-file" accept=".pgn,.txt">
+    <div class="load-sources">
+      <label class="file-btn">📄 Archivo PGN
+        <input type="file" id="pgn-file" accept=".pgn,.txt">
+      </label>
+      <label class="file-btn">🖼️ Imagen del tablero
+        <input type="file" id="board-image-file" accept="image/*">
+      </label>
+    </div>
+
+    <!-- editor de posicion detectada en la imagen -->
+    <div id="board-vision" class="hidden">
+      <div id="bv-status"></div>
+      <div id="bv-editor">
+        <div id="bv-board"></div>
+        <div id="bv-tools">
+          <div id="bv-palette"></div>
+          <div class="bv-controls">
+            <label class="bv-turn-label">Mueven
+              <select id="bv-turn">
+                <option value="w">Blancas</option>
+                <option value="b">Negras</option>
+              </select>
+            </label>
+            <button class="btn" id="bv-flip" title="Girar el tablero 180°">🔄 Girar</button>
+            <button class="btn" id="bv-clear" title="Vaciar el tablero">🗑 Vaciar</button>
+          </div>
+        </div>
+      </div>
+      <p class="bv-hint">Toca una pieza de la paleta y luego las casillas para corregir lo que haga falta.</p>
+    </div>
+
     <div class="actions">
       <button class="btn primary" id="btn-pgn-load">Cargar</button>
       <button class="btn" id="btn-pgn-close">Cancelar</button>
@@ -215,6 +244,7 @@
   <script src="js/Cell.js"></script>
   <script src="js/factory.js"></script>
   <script src="js/pgnParser.js"></script>
+  <script src="js/boardVision.js"></script>
   <script src="js/puzzles.js"></script>
   <script src="js/sound.js"></script>
   <script src="js/game.js"></script>

--- a/juegos/Chess3D/js/boardVision.js
+++ b/juegos/Chess3D/js/boardVision.js
@@ -1,0 +1,365 @@
+// boardVision.js
+// Analiza una imagen cualquiera de un tablero de ajedrez (PNG, JPG, JPEG,
+// WEBP, GIF...) y trata de reconstruir la posicion de las piezas.
+//
+// Todo el procesado ocurre en el navegador con <canvas>, sin subir la imagen
+// a ningun sitio. El resultado es una mejor estimacion: por eso la interfaz
+// muestra despues un editor para que el usuario corrija cualquier casilla
+// antes de cargar la partida.
+//
+// Estrategia:
+//   1. Recortar los margenes lisos y quedarnos con el cuadrado del tablero.
+//   2. Dividirlo en 8x8 casillas.
+//   3. Por casilla: estimar el color del fondo (anillo exterior), decidir si
+//      esta ocupada, de que color es la pieza y, por la silueta, que pieza es.
+//   4. El tipo de pieza se decide comparando la silueta detectada con las
+//      siluetas de las piezas Unicode (peon, caballo, alfil, torre, dama, rey).
+/* global document, Image, Uint8Array, Promise */
+"use strict";
+
+var BoardVision = (function () {
+
+	var GRID = 24;          // resolucion de la silueta normalizada
+	var COLOR_TOL = 52;     // distancia RGB para separar pieza de fondo
+	var templates = null;   // siluetas de referencia por tipo de pieza
+
+	/* ============ utilidades de mascara ============ */
+
+	function luminance(r, g, b) {
+		return 0.299 * r + 0.587 * g + 0.114 * b;
+	}
+
+	function colorDist(r1, g1, b1, r2, g2, b2) {
+		var dr = r1 - r2, dg = g1 - g2, db = b1 - b2;
+		return Math.sqrt(dr * dr + dg * dg + db * db);
+	}
+
+	function median(arr) {
+		if (arr.length === 0) { return 0; }
+		var a = arr.slice().sort(function (x, y) { return x - y; });
+		return a[Math.floor(a.length / 2)];
+	}
+
+	// Recorta la mascara a su caja, la reescala manteniendo la proporcion y la
+	// centra en una rejilla fija GRID x GRID para poder comparar siluetas.
+	function normalizeMask(mask, w, h) {
+		var minx = w, miny = h, maxx = -1, maxy = -1;
+		var x, y;
+		for (y = 0; y < h; y++) {
+			for (x = 0; x < w; x++) {
+				if (mask[y * w + x]) {
+					if (x < minx) { minx = x; }
+					if (x > maxx) { maxx = x; }
+					if (y < miny) { miny = y; }
+					if (y > maxy) { maxy = y; }
+				}
+			}
+		}
+		var out = new Uint8Array(GRID * GRID);
+		if (maxx < 0) { return out; }
+
+		var bw = maxx - minx + 1;
+		var bh = maxy - miny + 1;
+		var scale = Math.min(GRID / bw, GRID / bh);
+		var dw = Math.max(1, Math.round(bw * scale));
+		var dh = Math.max(1, Math.round(bh * scale));
+		var offx = Math.floor((GRID - dw) / 2);
+		var offy = Math.floor((GRID - dh) / 2);
+
+		for (var oy = 0; oy < dh; oy++) {
+			var sy = miny + Math.floor((oy + 0.5) / dh * bh);
+			for (var ox = 0; ox < dw; ox++) {
+				var sx = minx + Math.floor((ox + 0.5) / dw * bw);
+				if (mask[sy * w + sx]) {
+					out[(offy + oy) * GRID + (offx + ox)] = 1;
+				}
+			}
+		}
+		return out;
+	}
+
+	// Espejo horizontal de una mascara GRID x GRID.
+	function hmirror(m) {
+		var o = new Uint8Array(m.length);
+		for (var y = 0; y < GRID; y++) {
+			for (var x = 0; x < GRID; x++) {
+				o[y * GRID + (GRID - 1 - x)] = m[y * GRID + x];
+			}
+		}
+		return o;
+	}
+
+	// Coeficiente de Dice entre dos mascaras del mismo tamano.
+	function dice(a, b) {
+		var inter = 0, sa = 0, sb = 0;
+		for (var i = 0; i < a.length; i++) {
+			if (a[i]) { sa++; }
+			if (b[i]) { sb++; }
+			if (a[i] && b[i]) { inter++; }
+		}
+		if (sa + sb === 0) { return 0; }
+		return (2 * inter) / (sa + sb);
+	}
+
+	/* ============ plantillas de piezas ============ */
+
+	function buildTemplates() {
+		if (templates) { return templates; }
+		templates = {};
+		var glyphs = {
+			p: "♟", // peon
+			n: "♞", // caballo
+			b: "♝", // alfil
+			r: "♜", // torre
+			q: "♛", // dama
+			k: "♚"  // rey
+		};
+		var S = 90;
+		var c = document.createElement("canvas");
+		c.width = S;
+		c.height = S;
+		var ctx = c.getContext("2d");
+		ctx.textAlign = "center";
+		ctx.textBaseline = "middle";
+		ctx.font = Math.floor(S * 0.82) + "px 'Segoe UI Symbol','DejaVu Sans','Arial Unicode MS',serif";
+
+		Object.keys(glyphs).forEach(function (key) {
+			ctx.clearRect(0, 0, S, S);
+			ctx.fillStyle = "#000";
+			ctx.fillText(glyphs[key], S / 2, S / 2 + S * 0.02);
+			var data = ctx.getImageData(0, 0, S, S).data;
+			var mask = new Uint8Array(S * S);
+			for (var i = 0; i < S * S; i++) {
+				mask[i] = data[i * 4 + 3] > 40 ? 1 : 0;
+			}
+			templates[key] = normalizeMask(mask, S, S);
+		});
+		return templates;
+	}
+
+	/* ============ carga de la imagen ============ */
+
+	function loadImage(src) {
+		return new Promise(function (resolve, reject) {
+			var img = new Image();
+			img.onload = function () { resolve(img); };
+			img.onerror = function () { reject(new Error("No se pudo leer la imagen")); };
+			img.src = src;
+		});
+	}
+
+	/* ============ deteccion del tablero ============ */
+
+	// Varianza de luminancia a lo largo de una fila (o columna). Los margenes
+	// lisos tienen varianza casi nula; el tablero (casillas alternas + piezas)
+	// tiene varianza alta.
+	function lineVariance(data, W, H, index, isRow) {
+		var n = isRow ? W : H;
+		var step = 8; // muestreo para ir rapido
+		var sum = 0, sum2 = 0, count = 0;
+		for (var k = 0; k < n; k += step) {
+			var x = isRow ? k : index;
+			var y = isRow ? index : k;
+			var o = (y * W + x) * 4;
+			var l = luminance(data[o], data[o + 1], data[o + 2]);
+			sum += l;
+			sum2 += l * l;
+			count++;
+		}
+		if (count === 0) { return 0; }
+		var mean = sum / count;
+		return (sum2 / count) - (mean * mean);
+	}
+
+	function detectBoard(data, W, H) {
+		var UNIFORM = 150; // varianza por debajo de la cual la linea es "lisa"
+		var x0 = 0, x1 = W - 1, y0 = 0, y1 = H - 1;
+		var limitY = Math.floor(H * 0.35);
+		var limitX = Math.floor(W * 0.35);
+
+		while (y0 < limitY && lineVariance(data, W, H, y0, true) < UNIFORM) { y0++; }
+		while (y1 > H - 1 - limitY && lineVariance(data, W, H, y1, true) < UNIFORM) { y1--; }
+		while (x0 < limitX && lineVariance(data, W, H, x0, false) < UNIFORM) { x0++; }
+		while (x1 > W - 1 - limitX && lineVariance(data, W, H, x1, false) < UNIFORM) { x1--; }
+
+		var bw = x1 - x0 + 1;
+		var bh = y1 - y0 + 1;
+		if (bw < 16 || bh < 16) {
+			// recorte degenerado: usar la imagen entera
+			x0 = 0; y0 = 0; bw = W; bh = H;
+		}
+
+		// El tablero es cuadrado: quedarnos con el cuadrado centrado.
+		var side = Math.min(bw, bh);
+		var ox = x0 + Math.floor((bw - side) / 2);
+		var oy = y0 + Math.floor((bh - side) / 2);
+		return { x: ox, y: oy, side: side };
+	}
+
+	// Rellena los huecos de una mascara binaria: todo pixel de fondo (0) que
+	// no este conectado con el borde de la region esta "encerrado" por el
+	// primer plano, asi que pasa a formar parte de el. Convierte un contorno
+	// cerrado en una silueta solida.
+	function fillHoles(mask, w, h) {
+		var outside = new Uint8Array(w * h);
+		var stack = [];
+		var i, x, y;
+		// sembrar desde todos los pixeles de fondo del borde
+		for (x = 0; x < w; x++) {
+			if (!mask[x]) { stack.push(x); }
+			var b = (h - 1) * w + x;
+			if (!mask[b]) { stack.push(b); }
+		}
+		for (y = 0; y < h; y++) {
+			if (!mask[y * w]) { stack.push(y * w); }
+			var rr = y * w + (w - 1);
+			if (!mask[rr]) { stack.push(rr); }
+		}
+		while (stack.length) {
+			var p = stack.pop();
+			if (outside[p]) { continue; }
+			outside[p] = 1;
+			var cx = p % w, cy = (p - cx) / w;
+			if (cx > 0 && !mask[p - 1] && !outside[p - 1]) { stack.push(p - 1); }
+			if (cx < w - 1 && !mask[p + 1] && !outside[p + 1]) { stack.push(p + 1); }
+			if (cy > 0 && !mask[p - w] && !outside[p - w]) { stack.push(p - w); }
+			if (cy < h - 1 && !mask[p + w] && !outside[p + w]) { stack.push(p + w); }
+		}
+		for (i = 0; i < mask.length; i++) {
+			if (!mask[i] && !outside[i]) { mask[i] = 1; }
+		}
+	}
+
+	/* ============ clasificacion de una casilla ============ */
+
+	function classifyCell(data, W, H, cellX, cellY, cell) {
+		var ringR = [], ringG = [], ringB = [];
+		var x, y;
+
+		var x0 = Math.round(cellX);
+		var y0 = Math.round(cellY);
+		var cs = Math.round(cell);
+
+		// Region de silueta: 10%..90% de la casilla (evita las lineas de rejilla).
+		var mLo = Math.round(cs * 0.10);
+		var mHi = Math.round(cs * 0.90);
+		var maskW = mHi - mLo;
+		var maskH = mHi - mLo;
+		var mask = new Uint8Array(maskW * maskH);
+		var lumArr = new Float32Array(maskW * maskH); // luminancia por pixel
+
+		// 1) color de fondo = mediana del anillo exterior (pieza suele ir centrada)
+		for (y = mLo; y < mHi; y++) {
+			for (x = mLo; x < mHi; x++) {
+				var fx = (x - mLo) / cs; // 0..0.8 aprox
+				var fy = (y - mLo) / cs;
+				var edge = fx < 0.12 || fx > 0.68 || fy < 0.12 || fy > 0.68;
+				if (!edge) { continue; }
+				var ry = y0 + y, rx = x0 + x;
+				if (rx < 0 || ry < 0 || rx >= W || ry >= H) { continue; }
+				var o = (ry * W + rx) * 4;
+				ringR.push(data[o]);
+				ringG.push(data[o + 1]);
+				ringB.push(data[o + 2]);
+			}
+		}
+		var bgR = median(ringR), bgG = median(ringG), bgB = median(ringB);
+
+		// 2) mascara del primer plano (pixeles que difieren del fondo)
+		for (y = 0; y < maskH; y++) {
+			for (x = 0; x < maskW; x++) {
+				var px = x0 + mLo + x;
+				var py = y0 + mLo + y;
+				var idx = y * maskW + x;
+				if (px < 0 || py < 0 || px >= W || py >= H) { continue; }
+				var oo = (py * W + px) * 4;
+				var r = data[oo], g = data[oo + 1], b = data[oo + 2];
+				lumArr[idx] = luminance(r, g, b);
+				if (colorDist(r, g, b, bgR, bgG, bgB) > COLOR_TOL) {
+					mask[idx] = 1;
+				}
+			}
+		}
+
+		// Rellenar el interior: si una pieza clara sobre casilla clara (o
+		// oscura sobre oscura) solo deja ver su contorno, el hueco encerrado
+		// se convierte en primer plano para recuperar la silueta solida.
+		fillHoles(mask, maskW, maskH);
+
+		// 3) estadisticas del primer plano (ya relleno)
+		var fgBright = 0, fgDark = 0, fgCount = 0;
+		var innerLum = [];
+		for (var i = 0; i < mask.length; i++) {
+			if (mask[i]) {
+				fgCount++;
+				var l = lumArr[i];
+				innerLum.push(l);
+				if (l > 150) { fgBright++; }
+				else if (l < 105) { fgDark++; }
+			}
+		}
+
+		var frac = mask.length > 0 ? fgCount / mask.length : 0;
+		if (frac < 0.05) {
+			return null; // casilla vacia
+		}
+
+		// 4) color de la pieza: el cuerpo (mediana de luminancia del primer
+		//    plano) decide. Las piezas blancas tienen relleno claro; las
+		//    negras, relleno oscuro. Como respaldo, el recuento de pixeles
+		//    muy claros/oscuros.
+		var medLum = median(innerLum);
+		var isWhite;
+		if (medLum > 150) { isWhite = true; }
+		else if (medLum < 100) { isWhite = false; }
+		else { isWhite = fgBright >= fgDark; }
+
+		// 5) tipo de pieza por comparacion de siluetas. El caballo puede mirar
+		//    a cualquier lado, asi que se compara tambien con la silueta espejo.
+		var norm = normalizeMask(mask, maskW, maskH);
+		var mirror = hmirror(norm);
+		var tpl = buildTemplates();
+		var bestType = "p", bestScore = -1;
+		Object.keys(tpl).forEach(function (t) {
+			var s = Math.max(dice(norm, tpl[t]), dice(mirror, tpl[t]));
+			if (s > bestScore) { bestScore = s; bestType = t; }
+		});
+
+		return isWhite ? bestType.toUpperCase() : bestType;
+	}
+
+	/* ============ API publica ============ */
+
+	// analyze(dataUrl) -> Promise<{ board: (char|null)[8][8] }>
+	// board[0] es la fila superior de la imagen.
+	function analyze(dataUrl) {
+		return loadImage(dataUrl).then(function (img) {
+			var maxSide = 720;
+			var scale = Math.min(1, maxSide / Math.max(img.width, img.height));
+			var W = Math.max(1, Math.round(img.width * scale));
+			var H = Math.max(1, Math.round(img.height * scale));
+
+			var canvas = document.createElement("canvas");
+			canvas.width = W;
+			canvas.height = H;
+			var ctx = canvas.getContext("2d");
+			ctx.drawImage(img, 0, 0, W, H);
+			var data = ctx.getImageData(0, 0, W, H).data;
+
+			var box = detectBoard(data, W, H);
+			var cell = box.side / 8;
+
+			var board = [];
+			for (var r = 0; r < 8; r++) {
+				var row = [];
+				for (var c = 0; c < 8; c++) {
+					row.push(classifyCell(data, W, H, box.x + c * cell, box.y + r * cell, cell));
+				}
+				board.push(row);
+			}
+			return { board: board };
+		});
+	}
+
+	return { analyze: analyze };
+})();

--- a/juegos/Chess3D/js/game.js
+++ b/juegos/Chess3D/js/game.js
@@ -1301,6 +1301,52 @@ var Game = (function () {
 		return true;
 	}
 
+	// Carga una posicion arbitraria (por ejemplo, la detectada en una imagen)
+	// a partir de un FEN y arranca una partida contra la IA desde ahi.
+	function loadFEN(fen) {
+		resetCommonState();
+		state.mode = "ai";
+		state.gameOver = false;
+
+		var err = InitializeFromFen(fen);
+		if (err && err.length) {
+			throw new Error(err);
+		}
+
+		g_allMoves = [];
+		sanHistory = [];
+		moveMeta = [];
+		lastMoveIdxs = [];
+		checkIdx = null;
+
+		state.playerWhite = whiteToMove();
+		validMoves = GenerateValidMoves();
+		updateCheckHighlight();
+		syncBoard();
+		cinematic = false;
+		cameraToSide(state.playerWhite);
+
+		ensureAnalysisStopped();
+		if (initBackgroundEngine()) {
+			backgroundEngine.postMessage("position " + GetFen());
+		}
+
+		if (ui()) {
+			ui().onNewGameStarted({
+				mode: "ai",
+				playerWhite: state.playerWhite,
+				level: state.level,
+				levelInfo: levels[state.level],
+				clock: false,
+				loaded: true
+			});
+			ui().onHistoryRebuilt(sanHistory.slice());
+			ui().onTurn(whiteToMove());
+			ui().onCapturedUpdate(capturedSummary());
+		}
+		return true;
+	}
+
 	/* ================= rafaga de mates ================= */
 
 	function shuffled(list) {
@@ -1487,6 +1533,7 @@ var Game = (function () {
 		flipCamera: flipCamera,
 		getPGN: getPGN,
 		loadPGNText: loadPGNText,
+		loadFEN: loadFEN,
 		getFen: function () { return GetFen(); },
 		isAnimating: function () { return animating; },
 		// para depuracion y pruebas automatizadas

--- a/juegos/Chess3D/js/ui.js
+++ b/juegos/Chess3D/js/ui.js
@@ -1,6 +1,6 @@
 // Interfaz de usuario: menu principal, HUD, modales, estadisticas y toasts.
 // Se comunica con el nucleo del juego a traves de window.Game / window.UI.
-/* global document, window, localStorage, Game, Sound, console */
+/* global document, window, localStorage, Game, Sound, console, BoardVision, FileReader */
 /* global piecePawn, pieceKnight, pieceBishop, pieceRook, pieceQueen */
 "use strict";
 
@@ -13,6 +13,15 @@ var UI = (function () {
 	var promoCallback = null;
 	var toastTimer = null;
 	var estadoTimer = null;
+
+	// glifos Unicode para el editor de posicion (a partir de imagen)
+	var PIECE_GLYPHS = {
+		p: "♟", n: "♞", b: "♝", r: "♜", q: "♛", k: "♚"
+	};
+	// estado del editor de posicion detectada
+	var bvBoard = null; // matriz 8x8, fila 0 = arriba (rango 8, blancas abajo)
+	var bvBrush = "P";  // pieza seleccionada en la paleta (null = borrar)
+	var bvTurn = "w";
 
 	/* ================= estadisticas ================= */
 
@@ -449,7 +458,11 @@ var UI = (function () {
 		$("card-ai").addEventListener("click", function () { Sound.click(); openConfig("ai"); });
 		$("card-2p").addEventListener("click", function () { Sound.click(); openConfig("2p"); });
 		$("card-puzzle").addEventListener("click", function () { Sound.click(); startPuzzle(); });
-		$("card-load").addEventListener("click", function () { Sound.click(); openModal("modal-pgn"); });
+		$("card-load").addEventListener("click", function () {
+			Sound.click();
+			resetBoardVision();
+			openModal("modal-pgn");
+		});
 		$("btn-config-back").addEventListener("click", function () {
 			Sound.click();
 			hide("menu-config");
@@ -518,23 +531,37 @@ var UI = (function () {
 			});
 		});
 
-		// PGN
+		// PGN / posicion desde imagen
 		$("btn-pgn-close").addEventListener("click", function () { Sound.click(); closeModals(); });
 		$("btn-pgn-load").addEventListener("click", function () {
 			Sound.click();
+			// si hay una posicion detectada en pantalla, se carga esa
+			if (!$("board-vision").classList.contains("hidden") && bvBoard) {
+				tryLoadPosition();
+				return;
+			}
 			var text = $("pgn-text").value.trim();
-			if (!text) { toast("Pega un PGN o elige un archivo"); return; }
+			if (!text) { toast("Pega un PGN, o sube una imagen del tablero"); return; }
 			tryLoadPGN(text);
 		});
 		$("pgn-file").addEventListener("change", function (evt) {
 			var file = evt.target.files[0];
 			if (!file) { return; }
+			resetBoardVision();
 			var reader = new FileReader();
 			reader.onload = function (e) {
 				$("pgn-text").value = e.target.result;
 				tryLoadPGN(e.target.result);
 			};
 			reader.readAsText(file);
+		});
+		$("board-image-file").addEventListener("change", function (evt) {
+			analyzeBoardImage(evt.target.files[0]);
+		});
+		$("bv-flip").addEventListener("click", bvFlip);
+		$("bv-clear").addEventListener("click", bvClear);
+		$("bv-turn").addEventListener("change", function (evt) {
+			bvTurn = evt.target.value === "b" ? "b" : "w";
 		});
 
 		// niveles de IA
@@ -558,6 +585,198 @@ var UI = (function () {
 				}
 			}
 		});
+	}
+
+	/* ============ editor de posicion desde imagen ============ */
+
+	function emptyBoard() {
+		var b = [];
+		for (var r = 0; r < 8; r++) {
+			b.push([null, null, null, null, null, null, null, null]);
+		}
+		return b;
+	}
+
+	function glyphFor(ch) {
+		return ch ? PIECE_GLYPHS[ch.toLowerCase()] : "";
+	}
+
+	function isWhitePiece(ch) {
+		return ch && ch === ch.toUpperCase();
+	}
+
+	function bvRenderBoard() {
+		var host = $("bv-board");
+		host.innerHTML = "";
+		for (var r = 0; r < 8; r++) {
+			for (var c = 0; c < 8; c++) {
+				var cell = document.createElement("button");
+				cell.type = "button";
+				cell.className = "bv-cell " + (((r + c) % 2 === 0) ? "light" : "dark");
+				cell.dataset.r = r;
+				cell.dataset.c = c;
+				var ch = bvBoard[r][c];
+				if (ch) {
+					var span = document.createElement("span");
+					span.className = isWhitePiece(ch) ? "bv-piece white-piece" : "bv-piece black-piece";
+					span.textContent = glyphFor(ch);
+					cell.appendChild(span);
+				}
+				cell.addEventListener("click", bvCellClick);
+				host.appendChild(cell);
+			}
+		}
+	}
+
+	function bvCellClick(evt) {
+		var el = evt.currentTarget;
+		var r = parseInt(el.dataset.r, 10);
+		var c = parseInt(el.dataset.c, 10);
+		bvBoard[r][c] = bvBrush; // null borra la casilla
+		Sound.click();
+		bvRenderBoard();
+	}
+
+	function bvRenderPalette() {
+		var host = $("bv-palette");
+		host.innerHTML = "";
+		var items = ["K", "Q", "R", "B", "N", "P", "k", "q", "r", "b", "n", "p", null];
+		items.forEach(function (ch) {
+			var btn = document.createElement("button");
+			btn.type = "button";
+			btn.className = "bv-brush";
+			if (ch === null) {
+				btn.classList.add("erase");
+				btn.textContent = "⌫";
+				btn.title = "Borrar casilla";
+			} else {
+				var span = document.createElement("span");
+				span.className = isWhitePiece(ch) ? "white-piece" : "black-piece";
+				span.textContent = glyphFor(ch);
+				btn.appendChild(span);
+			}
+			if (ch === bvBrush) { btn.classList.add("active"); }
+			btn.addEventListener("click", function () {
+				bvBrush = ch;
+				Sound.click();
+				bvRenderPalette();
+			});
+			host.appendChild(btn);
+		});
+	}
+
+	function bvFlip() {
+		var flipped = emptyBoard();
+		for (var r = 0; r < 8; r++) {
+			for (var c = 0; c < 8; c++) {
+				flipped[r][c] = bvBoard[7 - r][7 - c];
+			}
+		}
+		bvBoard = flipped;
+		Sound.click();
+		bvRenderBoard();
+	}
+
+	function bvClear() {
+		bvBoard = emptyBoard();
+		Sound.click();
+		bvRenderBoard();
+	}
+
+	function bvBuildFen() {
+		var rows = bvBoard.map(function (row) {
+			var s = "";
+			var empty = 0;
+			row.forEach(function (ch) {
+				if (!ch) {
+					empty++;
+				} else {
+					if (empty) { s += empty; empty = 0; }
+					s += ch;
+				}
+			});
+			if (empty) { s += empty; }
+			return s;
+		});
+		return rows.join("/") + " " + bvTurn + " - - 0 1";
+	}
+
+	function countPiece(ch) {
+		var n = 0;
+		for (var r = 0; r < 8; r++) {
+			for (var c = 0; c < 8; c++) {
+				if (bvBoard[r][c] === ch) { n++; }
+			}
+		}
+		return n;
+	}
+
+	function resetBoardVision() {
+		bvBoard = null;
+		bvBrush = "P";
+		bvTurn = "w";
+		hide("board-vision");
+		$("bv-status").textContent = "";
+		if ($("bv-turn")) { $("bv-turn").value = "w"; }
+		if ($("board-image-file")) { $("board-image-file").value = ""; }
+		$("btn-pgn-load").textContent = "Cargar";
+	}
+
+	function showBoardVision(result) {
+		bvBoard = result.board;
+		bvTurn = "w";
+		$("bv-turn").value = "w";
+		show("board-vision");
+		var pieces = 0;
+		for (var r = 0; r < 8; r++) {
+			for (var c = 0; c < 8; c++) {
+				if (bvBoard[r][c]) { pieces++; }
+			}
+		}
+		$("bv-status").textContent = "Detectadas " + pieces +
+			" piezas. Revisa y corrige si hace falta.";
+		$("btn-pgn-load").textContent = "Cargar posición";
+		bvRenderPalette();
+		bvRenderBoard();
+	}
+
+	function analyzeBoardImage(file) {
+		if (!file) { return; }
+		if (typeof BoardVision === "undefined") {
+			toast("El analizador de imágenes no está disponible");
+			return;
+		}
+		$("bv-status").textContent = "Analizando la imagen…";
+		show("board-vision");
+		var reader = new FileReader();
+		reader.onload = function (e) {
+			BoardVision.analyze(e.target.result).then(function (result) {
+				showBoardVision(result);
+			}).catch(function (err) {
+				console.error(err);
+				$("bv-status").textContent = "";
+				hide("board-vision");
+				toast("No se pudo analizar esa imagen");
+			});
+		};
+		reader.onerror = function () { toast("No se pudo leer el archivo"); };
+		reader.readAsDataURL(file);
+	}
+
+	function tryLoadPosition() {
+		if (countPiece("K") !== 1 || countPiece("k") !== 1) {
+			toast("Debe haber un rey blanco y un rey negro");
+			return;
+		}
+		try {
+			Game.loadFEN(bvBuildFen());
+			closeModals();
+			hide("menu");
+			toast("Posición cargada, sigue jugando contra la IA");
+		} catch (err) {
+			console.error(err);
+			toast("Esa posición no es válida");
+		}
 	}
 
 	function tryLoadPGN(text) {


### PR DESCRIPTION
Ahora la seccion "Cargar partida" acepta, ademas de PGN, una imagen del tablero en cualquier formato (PNG, JPG, JPEG, WEBP...). La imagen se analiza en el navegador para reconstruir la posicion de las piezas y se muestra un editor para corregir cualquier casilla antes de cargarla contra la IA.

- boardVision.js: analisis por <canvas> (recorte del tablero, ocupacion por casilla, color de pieza por luminancia y tipo por comparacion de siluetas con relleno de huecos para piezas de bajo contraste).
- game.js: nueva funcion loadFEN para arrancar una partida desde una posicion.
- ui.js + index.html + style.css: entrada de imagen y editor de posicion (paleta de piezas, girar tablero, vaciar y turno).